### PR TITLE
ci: Fix coverage package name

### DIFF
--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -81,7 +81,7 @@ jobs:
         run: mvn org.apache.maven.plugins:maven-dependency-plugin:2.8:get -Dartifact=org.jacoco:org.jacoco.agent:0.8.11:jar:runtime -Ddest=target/jacocoagent.jar
       - name: Run tox to measure timefold solver python code coverage from Python tests
         continue-on-error: true # Sometimes the JVM segfaults on SUCCESSFUL tests with Java 17 (and always with Java 11)
-        run: python -m tox -- --cov=timefold-solver --cov-report=xml:target/coverage.xml --cov-config=tox.ini --cov-branch --cov-append --jacoco-agent=./target/jacocoagent.jar
+        run: python -m tox -- --cov=timefold --cov-report=xml:target/coverage.xml --cov-config=tox.ini --cov-branch --cov-append --jacoco-agent=./target/jacocoagent.jar
       - name: Run tox to measure jpyinterpreter code coverage from Python tests
         continue-on-error: true # Sometimes the JVM segfaults on SUCCESSFUL tests with Java 17 (and always with Java 11)
         working-directory: ./jpyinterpreter


### PR DESCRIPTION
`--cov` takes package path, not package name.

This makes the generated `coverage.xml` correct (tested locally). However, we probably still need to set `SONARCLOUD_TOKEN` and create the `timefold_solver_python` project in SonarCloud.