### PR TITLE
chore: Rename internal methods of PythonLikeObject to use '$' instead of '__'

### DIFF
--- a/jpyinterpreter/src/main/java/ai/timefold/jpyinterpreter/CPythonBackedPythonInterpreter.java
+++ b/jpyinterpreter/src/main/java/ai/timefold/jpyinterpreter/CPythonBackedPythonInterpreter.java
@@ -113,7 +113,7 @@ public class CPythonBackedPythonInterpreter implements PythonInterpreter {
             OpaquePythonReference pythonObject,
             Map<Number, PythonLikeObject> instanceMap) {
         Map<String, PythonLikeObject> dict = getPythonReferenceDict(pythonObject, instanceMap);
-        dict.forEach(javaObject::__setAttribute);
+        dict.forEach(javaObject::$setAttribute);
     }
 
     public static PythonLikeObject callPythonReference(OpaquePythonReference object, List<PythonLikeObject> positionalArguments,

--- a/jpyinterpreter/src/main/java/ai/timefold/jpyinterpreter/PythonClassTranslator.java
+++ b/jpyinterpreter/src/main/java/ai/timefold/jpyinterpreter/PythonClassTranslator.java
@@ -144,7 +144,7 @@ public class PythonClassTranslator {
         classWriter.visit(Opcodes.V11, Modifier.PUBLIC, internalClassName, null,
                 superClassType.getJavaTypeInternalName(), interfaces);
 
-        pythonCompiledClass.staticAttributeNameToObject.forEach(pythonLikeType::__setAttribute);
+        pythonCompiledClass.staticAttributeNameToObject.forEach(pythonLikeType::$setAttribute);
 
         classWriter.visitField(Modifier.PUBLIC | Modifier.STATIC, TYPE_FIELD_NAME, Type.getDescriptor(PythonLikeType.class),
                 null, null);
@@ -154,7 +154,7 @@ public class PythonClassTranslator {
 
         for (Map.Entry<String, PythonLikeObject> staticAttributeEntry : pythonCompiledClass.staticAttributeNameToObject
                 .entrySet()) {
-            pythonLikeType.__setAttribute(staticAttributeEntry.getKey(), staticAttributeEntry.getValue());
+            pythonLikeType.$setAttribute(staticAttributeEntry.getKey(), staticAttributeEntry.getValue());
         }
 
         Map<String, PythonLikeType> attributeNameToTypeMap = new HashMap<>();
@@ -259,17 +259,17 @@ public class PythonClassTranslator {
         PythonBytecodeToJavaBytecodeTranslator.writeClassOutput(BuiltinTypes.classNameToBytecode, className,
                 classWriter.toByteArray());
 
-        pythonLikeType.__setAttribute("__name__", PythonString.valueOf(pythonCompiledClass.className));
-        pythonLikeType.__setAttribute("__qualname__", PythonString.valueOf(pythonCompiledClass.qualifiedName));
-        pythonLikeType.__setAttribute("__module__", PythonString.valueOf(pythonCompiledClass.module));
+        pythonLikeType.$setAttribute("__name__", PythonString.valueOf(pythonCompiledClass.className));
+        pythonLikeType.$setAttribute("__qualname__", PythonString.valueOf(pythonCompiledClass.qualifiedName));
+        pythonLikeType.$setAttribute("__module__", PythonString.valueOf(pythonCompiledClass.module));
 
         PythonLikeDict annotations = new PythonLikeDict();
         pythonCompiledClass.typeAnnotations.forEach((name, type) -> annotations.put(PythonString.valueOf(name), type));
-        pythonLikeType.__setAttribute("__annotations__", annotations);
+        pythonLikeType.$setAttribute("__annotations__", annotations);
 
         PythonLikeTuple mro = new PythonLikeTuple();
         mro.addAll(superTypeList);
-        pythonLikeType.__setAttribute("__mro__", mro);
+        pythonLikeType.$setAttribute("__mro__", mro);
 
         Class<? extends PythonLikeObject> generatedClass;
         try {
@@ -339,7 +339,7 @@ public class PythonClassTranslator {
                 objectInstance.$setCPythonId(PythonInteger.valueOf(pythonReferenceId.longValue()));
                 objectInstance.$setInstanceMap(instanceMap);
                 objectInstance.$readFieldsFromCPythonReference();
-                pythonLikeType.__setAttribute(attributeName, objectInstance);
+                pythonLikeType.$setAttribute(attributeName, objectInstance);
             } catch (InstantiationException | IllegalAccessException | InvocationTargetException | NoSuchMethodException e) {
                 throw new RuntimeException("Unable to construct instance of class (" + generatedClass + ")", e);
             }
@@ -442,7 +442,7 @@ public class PythonClassTranslator {
 
             generatedClass.getField(getJavaMethodName(methodEntry.getKey()))
                     .set(null, functionInstance);
-            pythonLikeType.__setAttribute(methodEntry.getKey(), translatedPythonMethodWrapper);
+            pythonLikeType.$setAttribute(methodEntry.getKey(), translatedPythonMethodWrapper);
             return functionClass;
         } catch (IllegalAccessException | NoSuchFieldException e) {
             throw new IllegalStateException("Impossible State: could not access method (" + methodEntry.getKey()
@@ -508,7 +508,7 @@ public class PythonClassTranslator {
                 Type.getDescriptor(PythonLikeType.class));
         methodVisitor.visitLdcInsn(methodName);
         methodVisitor.visitMethodInsn(Opcodes.INVOKEINTERFACE, Type.getInternalName(PythonLikeObject.class),
-                "__getAttributeOrError",
+                "$getAttributeOrError",
                 Type.getMethodDescriptor(Type.getType(PythonLikeObject.class), Type.getType(String.class)),
                 true);
         methodVisitor.visitTypeInsn(Opcodes.CHECKCAST, Type.getInternalName(PythonLikeFunction.class));
@@ -805,7 +805,7 @@ public class PythonClassTranslator {
     public static void createGetAttribute(ClassWriter classWriter, String classInternalName, String superInternalName,
             Collection<String> instanceAttributes,
             Map<String, PythonLikeType> fieldToType) {
-        MethodVisitor methodVisitor = classWriter.visitMethod(Modifier.PUBLIC, "__getAttributeOrNull",
+        MethodVisitor methodVisitor = classWriter.visitMethod(Modifier.PUBLIC, "$getAttributeOrNull",
                 Type.getMethodDescriptor(Type.getType(PythonLikeObject.class),
                         Type.getType(String.class)),
                 null, null);
@@ -823,7 +823,7 @@ public class PythonClassTranslator {
         }, () -> {
             methodVisitor.visitVarInsn(Opcodes.ALOAD, 0);
             methodVisitor.visitVarInsn(Opcodes.ALOAD, 1);
-            methodVisitor.visitMethodInsn(Opcodes.INVOKESPECIAL, superInternalName, "__getAttributeOrNull",
+            methodVisitor.visitMethodInsn(Opcodes.INVOKESPECIAL, superInternalName, "$getAttributeOrNull",
                     Type.getMethodDescriptor(Type.getType(PythonLikeObject.class),
                             Type.getType(String.class)),
                     false);
@@ -837,7 +837,7 @@ public class PythonClassTranslator {
     public static void createSetAttribute(ClassWriter classWriter, String classInternalName, String superInternalName,
             Collection<String> instanceAttributes,
             Map<String, PythonLikeType> fieldToType) {
-        MethodVisitor methodVisitor = classWriter.visitMethod(Modifier.PUBLIC, "__setAttribute",
+        MethodVisitor methodVisitor = classWriter.visitMethod(Modifier.PUBLIC, "$setAttribute",
                 Type.getMethodDescriptor(Type.VOID_TYPE,
                         Type.getType(String.class),
                         Type.getType(PythonLikeObject.class)),
@@ -860,7 +860,7 @@ public class PythonClassTranslator {
             methodVisitor.visitVarInsn(Opcodes.ALOAD, 0);
             methodVisitor.visitVarInsn(Opcodes.ALOAD, 1);
             methodVisitor.visitVarInsn(Opcodes.ALOAD, 2);
-            methodVisitor.visitMethodInsn(Opcodes.INVOKESPECIAL, superInternalName, "__setAttribute",
+            methodVisitor.visitMethodInsn(Opcodes.INVOKESPECIAL, superInternalName, "$setAttribute",
                     Type.getMethodDescriptor(Type.VOID_TYPE,
                             Type.getType(String.class),
                             Type.getType(PythonLikeObject.class)),
@@ -875,7 +875,7 @@ public class PythonClassTranslator {
     public static void createDeleteAttribute(ClassWriter classWriter, String classInternalName, String superInternalName,
             Collection<String> instanceAttributes,
             Map<String, PythonLikeType> fieldToType) {
-        MethodVisitor methodVisitor = classWriter.visitMethod(Modifier.PUBLIC, "__deleteAttribute",
+        MethodVisitor methodVisitor = classWriter.visitMethod(Modifier.PUBLIC, "$deleteAttribute",
                 Type.getMethodDescriptor(Type.VOID_TYPE,
                         Type.getType(String.class)),
                 null, null);
@@ -894,7 +894,7 @@ public class PythonClassTranslator {
         }, () -> {
             methodVisitor.visitVarInsn(Opcodes.ALOAD, 0);
             methodVisitor.visitVarInsn(Opcodes.ALOAD, 1);
-            methodVisitor.visitMethodInsn(Opcodes.INVOKESPECIAL, superInternalName, "__deleteAttribute",
+            methodVisitor.visitMethodInsn(Opcodes.INVOKESPECIAL, superInternalName, "$deleteAttribute",
                     Type.getMethodDescriptor(Type.VOID_TYPE,
                             Type.getType(String.class)),
                     false);

--- a/jpyinterpreter/src/main/java/ai/timefold/jpyinterpreter/PythonGeneratorTranslator.java
+++ b/jpyinterpreter/src/main/java/ai/timefold/jpyinterpreter/PythonGeneratorTranslator.java
@@ -656,12 +656,12 @@ public class PythonGeneratorTranslator {
                                             methodVisitor.visitInsn(Opcodes.DUP);
                                             methodVisitor.visitMethodInsn(Opcodes.INVOKEINTERFACE,
                                                     Type.getInternalName(PythonLikeObject.class),
-                                                    "__getType", Type.getMethodDescriptor(Type.getType(PythonLikeType.class)),
+                                                    "$getType", Type.getMethodDescriptor(Type.getType(PythonLikeType.class)),
                                                     true);
                                             methodVisitor.visitLdcInsn("throw");
                                             methodVisitor.visitMethodInsn(Opcodes.INVOKEINTERFACE,
                                                     Type.getInternalName(PythonLikeObject.class),
-                                                    "__getAttributeOrNull",
+                                                    "$getAttributeOrNull",
                                                     Type.getMethodDescriptor(Type.getType(PythonLikeObject.class),
                                                             Type.getType(String.class)),
                                                     true);

--- a/jpyinterpreter/src/main/java/ai/timefold/jpyinterpreter/PythonLikeObject.java
+++ b/jpyinterpreter/src/main/java/ai/timefold/jpyinterpreter/PythonLikeObject.java
@@ -27,7 +27,7 @@ public interface PythonLikeObject {
      * @return The attribute of the object that corresponds with attributeName
      * @throws AttributeError if the attribute does not exist
      */
-    PythonLikeObject __getAttributeOrNull(String attributeName);
+    PythonLikeObject $getAttributeOrNull(String attributeName);
 
     /**
      * Gets an attribute by name.
@@ -36,8 +36,8 @@ public interface PythonLikeObject {
      * @return The attribute of the object that corresponds with attributeName
      * @throws AttributeError if the attribute does not exist
      */
-    default PythonLikeObject __getAttributeOrError(String attributeName) {
-        PythonLikeObject out = this.__getAttributeOrNull(attributeName);
+    default PythonLikeObject $getAttributeOrError(String attributeName) {
+        PythonLikeObject out = this.$getAttributeOrNull(attributeName);
         if (out == null) {
             throw new AttributeError("object '" + this + "' does not have attribute '" + attributeName + "'");
         }
@@ -50,52 +50,52 @@ public interface PythonLikeObject {
      * @param attributeName Name of the attribute to set
      * @param value Value to set the attribute to
      */
-    void __setAttribute(String attributeName, PythonLikeObject value);
+    void $setAttribute(String attributeName, PythonLikeObject value);
 
     /**
      * Delete an attribute by name.
      *
      * @param attributeName Name of the attribute to delete
      */
-    void __deleteAttribute(String attributeName);
+    void $deleteAttribute(String attributeName);
 
     /**
      * Returns the type describing the object
      *
      * @return the type describing the object
      */
-    PythonLikeType __getType();
+    PythonLikeType $getType();
 
     /**
-     * Return a generic version of {@link PythonLikeObject#__getType()}. This is used in bytecode
+     * Return a generic version of {@link PythonLikeObject#$getType()}. This is used in bytecode
      * generation and not at runtime. For example, for a list of integers, this return
      * list[int], while getType returns list. Both methods are needed so type([1,2,3]) is type(['a', 'b', 'c'])
      * return True.
      *
      * @return the generic version of this object's type. Must not be used in identity checks.
      */
-    default PythonLikeType __getGenericType() {
-        return __getType();
+    default PythonLikeType $getGenericType() {
+        return $getType();
     }
 
     default PythonLikeObject $method$__getattribute__(PythonString pythonName) {
         String name = pythonName.value;
-        PythonLikeObject objectResult = __getAttributeOrNull(name);
+        PythonLikeObject objectResult = $getAttributeOrNull(name);
         if (objectResult != null) {
             return objectResult;
         }
 
-        PythonLikeType type = __getType();
-        PythonLikeObject typeResult = type.__getAttributeOrNull(name);
+        PythonLikeType type = $getType();
+        PythonLikeObject typeResult = type.$getAttributeOrNull(name);
         if (typeResult != null) {
-            PythonLikeObject maybeDescriptor = typeResult.__getAttributeOrNull(PythonTernaryOperator.GET.dunderMethod);
+            PythonLikeObject maybeDescriptor = typeResult.$getAttributeOrNull(PythonTernaryOperator.GET.dunderMethod);
             if (maybeDescriptor == null) {
-                maybeDescriptor = typeResult.__getType().__getAttributeOrNull(PythonTernaryOperator.GET.dunderMethod);
+                maybeDescriptor = typeResult.$getType().$getAttributeOrNull(PythonTernaryOperator.GET.dunderMethod);
             }
 
             if (maybeDescriptor != null) {
                 if (!(maybeDescriptor instanceof PythonLikeFunction)) {
-                    throw new UnsupportedOperationException("'" + maybeDescriptor.__getType() + "' is not callable");
+                    throw new UnsupportedOperationException("'" + maybeDescriptor.$getType() + "' is not callable");
                 }
                 return TernaryDunderBuiltin.GET_DESCRIPTOR.invoke(typeResult, this, type);
             }
@@ -107,13 +107,13 @@ public interface PythonLikeObject {
 
     default PythonLikeObject $method$__setattr__(PythonString pythonName, PythonLikeObject value) {
         String name = pythonName.value;
-        __setAttribute(name, value);
+        $setAttribute(name, value);
         return PythonNone.INSTANCE;
     }
 
     default PythonLikeObject $method$__delattr__(PythonString pythonName) {
         String name = pythonName.value;
-        __deleteAttribute(name);
+        $deleteAttribute(name);
         return PythonNone.INSTANCE;
     }
 
@@ -141,7 +141,7 @@ public interface PythonLikeObject {
         } else {
             position = String.valueOf(System.identityHashCode(this));
         }
-        return PythonString.valueOf("<" + __getType().getTypeName() + " object at " + position + ">");
+        return PythonString.valueOf("<" + $getType().getTypeName() + " object at " + position + ">");
     }
 
     default PythonLikeObject $method$__format__() {
@@ -153,6 +153,6 @@ public interface PythonLikeObject {
     }
 
     default PythonLikeObject $method$__hash__() {
-        throw new TypeError("unhashable type: '" + __getType().getTypeName() + "'");
+        throw new TypeError("unhashable type: '" + $getType().getTypeName() + "'");
     }
 }

--- a/jpyinterpreter/src/main/java/ai/timefold/jpyinterpreter/PythonOverloadImplementor.java
+++ b/jpyinterpreter/src/main/java/ai/timefold/jpyinterpreter/PythonOverloadImplementor.java
@@ -74,7 +74,7 @@ public class PythonOverloadImplementor {
                     createDispatchForMethod(pythonLikeType, methodName, pythonLikeType.getMethodType(methodName).orElseThrow(),
                             pythonLikeType.getMethodKind(methodName)
                                     .orElse(PythonClassTranslator.PythonMethodKind.VIRTUAL_METHOD));
-            pythonLikeType.__setAttribute(methodName, overloadDispatch);
+            pythonLikeType.$setAttribute(methodName, overloadDispatch);
         }
 
         if (pythonLikeType.getConstructorType().isPresent()) {
@@ -82,7 +82,7 @@ public class PythonOverloadImplementor {
                     createDispatchForMethod(pythonLikeType, "__init__", pythonLikeType.getConstructorType().orElseThrow(),
                             PythonClassTranslator.PythonMethodKind.VIRTUAL_METHOD);
             pythonLikeType.setConstructor(overloadDispatch);
-            pythonLikeType.__setAttribute("__init__", overloadDispatch);
+            pythonLikeType.$setAttribute("__init__", overloadDispatch);
         }
     }
 
@@ -142,7 +142,7 @@ public class PythonOverloadImplementor {
     }
 
     private static void createGetTypeFunction(PythonClassTranslator.PythonMethodKind kind, ClassWriter classWriter) {
-        MethodVisitor methodVisitor = classWriter.visitMethod(Modifier.PUBLIC, "__getType",
+        MethodVisitor methodVisitor = classWriter.visitMethod(Modifier.PUBLIC, "$getType",
                 Type.getMethodDescriptor(Type.getType(PythonLikeType.class)),
                 null,
                 null);
@@ -484,7 +484,7 @@ public class PythonOverloadImplementor {
     public static String getCallErrorInfo(List<PythonLikeObject> positionalArgs,
             Map<PythonString, PythonLikeObject> namedArgs) {
         return "Could not find an overload that accept " + positionalArgs.stream()
-                .map(arg -> arg.__getType().getTypeName()).collect(Collectors.joining(", ", "(", ") argument types. "));
+                .map(arg -> arg.$getType().getTypeName()).collect(Collectors.joining(", ", "(", ") argument types. "));
     }
 
     private static SortedMap<PythonLikeType, List<PythonFunctionSignature>>

--- a/jpyinterpreter/src/main/java/ai/timefold/jpyinterpreter/builtins/BinaryDunderBuiltin.java
+++ b/jpyinterpreter/src/main/java/ai/timefold/jpyinterpreter/builtins/BinaryDunderBuiltin.java
@@ -39,12 +39,12 @@ public class BinaryDunderBuiltin implements PythonLikeFunction {
 
         PythonLikeObject object = positionalArguments.get(0);
         PythonLikeObject arg = positionalArguments.get(1);
-        PythonLikeFunction dunderMethod = (PythonLikeFunction) object.__getType().__getAttributeOrError(DUNDER_METHOD_NAME);
+        PythonLikeFunction dunderMethod = (PythonLikeFunction) object.$getType().$getAttributeOrError(DUNDER_METHOD_NAME);
         return dunderMethod.$call(List.of(object, arg), Map.of(), null);
     }
 
     public PythonLikeObject invoke(PythonLikeObject object, PythonLikeObject arg) {
-        PythonLikeFunction dunderMethod = (PythonLikeFunction) object.__getType().__getAttributeOrError(DUNDER_METHOD_NAME);
+        PythonLikeFunction dunderMethod = (PythonLikeFunction) object.$getType().$getAttributeOrError(DUNDER_METHOD_NAME);
         return dunderMethod.$call(List.of(object, arg), Map.of(), null);
     }
 }

--- a/jpyinterpreter/src/main/java/ai/timefold/jpyinterpreter/builtins/GlobalBuiltins.java
+++ b/jpyinterpreter/src/main/java/ai/timefold/jpyinterpreter/builtins/GlobalBuiltins.java
@@ -557,7 +557,7 @@ public class GlobalBuiltins {
             throw new ValueError("delattr expects 2 argument, got " + positionalArgs.size());
         }
 
-        object.__deleteAttribute(name.value);
+        object.$deleteAttribute(name.value);
 
         return PythonNone.INSTANCE;
     }
@@ -574,20 +574,20 @@ public class GlobalBuiltins {
             throw new TypeError("divmod() expects 2 positional arguments");
         }
 
-        PythonLikeObject maybeDivmod = left.__getType().__getAttributeOrNull("__divmod__");
+        PythonLikeObject maybeDivmod = left.$getType().$getAttributeOrNull("__divmod__");
         if (maybeDivmod != null) {
             PythonLikeObject result = ((PythonLikeFunction) maybeDivmod).$call(List.of(left, right), Map.of(), null);
             if (result != NotImplemented.INSTANCE) {
                 return result;
             }
-            maybeDivmod = right.__getType().__getAttributeOrNull("__rdivmod__");
+            maybeDivmod = right.$getType().$getAttributeOrNull("__rdivmod__");
             if (maybeDivmod != null) {
                 result = ((PythonLikeFunction) maybeDivmod).$call(List.of(right, left), Map.of(), null);
                 if (result != NotImplemented.INSTANCE) {
                     return result;
                 } else {
-                    PythonLikeObject maybeDiv = left.__getType().__getAttributeOrNull("__floordiv__");
-                    PythonLikeObject maybeMod = left.__getType().__getAttributeOrNull("__mod__");
+                    PythonLikeObject maybeDiv = left.$getType().$getAttributeOrNull("__floordiv__");
+                    PythonLikeObject maybeMod = left.$getType().$getAttributeOrNull("__mod__");
 
                     if (maybeDiv != null && maybeMod != null) {
                         PythonLikeObject divResult =
@@ -597,8 +597,8 @@ public class GlobalBuiltins {
                         if (divResult != NotImplemented.INSTANCE && modResult != NotImplemented.INSTANCE) {
                             return PythonLikeTuple.fromList(List.of(divResult, modResult));
                         } else {
-                            maybeDiv = right.__getType().__getAttributeOrNull("__rfloordiv__");
-                            maybeMod = right.__getType().__getAttributeOrNull("__rmod__");
+                            maybeDiv = right.$getType().$getAttributeOrNull("__rfloordiv__");
+                            maybeMod = right.$getType().$getAttributeOrNull("__rmod__");
 
                             if (maybeDiv != null && maybeMod != null) {
                                 divResult = ((PythonLikeFunction) maybeDiv).$call(List.of(right, left), Map.of(), null);
@@ -607,13 +607,13 @@ public class GlobalBuiltins {
                                     return PythonLikeTuple.fromList(List.of(divResult, modResult));
                                 } else {
                                     throw new TypeError(
-                                            "Unsupported operands for divmod: " + left.__getType() + ", " + right.__getType());
+                                            "Unsupported operands for divmod: " + left.$getType() + ", " + right.$getType());
                                 }
                             }
                         }
                     } else {
-                        maybeDiv = right.__getType().__getAttributeOrNull("__rfloordiv__");
-                        maybeMod = right.__getType().__getAttributeOrNull("__rmod__");
+                        maybeDiv = right.$getType().$getAttributeOrNull("__rfloordiv__");
+                        maybeMod = right.$getType().$getAttributeOrNull("__rmod__");
 
                         if (maybeDiv != null && maybeMod != null) {
                             PythonLikeObject divResult =
@@ -624,21 +624,21 @@ public class GlobalBuiltins {
                                 return PythonLikeTuple.fromList(List.of(divResult, modResult));
                             } else {
                                 throw new TypeError(
-                                        "Unsupported operands for divmod: " + left.__getType() + ", " + right.__getType());
+                                        "Unsupported operands for divmod: " + left.$getType() + ", " + right.$getType());
                             }
                         }
                     }
                 }
             }
         } else {
-            maybeDivmod = right.__getType().__getAttributeOrNull("__rdivmod__");
+            maybeDivmod = right.$getType().$getAttributeOrNull("__rdivmod__");
             if (maybeDivmod != null) {
                 PythonLikeObject result = ((PythonLikeFunction) maybeDivmod).$call(List.of(right, left), Map.of(), null);
                 if (result != NotImplemented.INSTANCE) {
                     return result;
                 } else {
-                    PythonLikeObject maybeDiv = left.__getType().__getAttributeOrNull("__floordiv__");
-                    PythonLikeObject maybeMod = left.__getType().__getAttributeOrNull("__mod__");
+                    PythonLikeObject maybeDiv = left.$getType().$getAttributeOrNull("__floordiv__");
+                    PythonLikeObject maybeMod = left.$getType().$getAttributeOrNull("__mod__");
 
                     if (maybeDiv != null && maybeMod != null) {
                         PythonLikeObject divResult =
@@ -648,8 +648,8 @@ public class GlobalBuiltins {
                         if (divResult != NotImplemented.INSTANCE && modResult != NotImplemented.INSTANCE) {
                             return PythonLikeTuple.fromList(List.of(divResult, modResult));
                         } else {
-                            maybeDiv = right.__getType().__getAttributeOrNull("__rfloordiv__");
-                            maybeMod = right.__getType().__getAttributeOrNull("__rmod__");
+                            maybeDiv = right.$getType().$getAttributeOrNull("__rfloordiv__");
+                            maybeMod = right.$getType().$getAttributeOrNull("__rmod__");
 
                             if (maybeDiv != null && maybeMod != null) {
                                 divResult = ((PythonLikeFunction) maybeDiv).$call(List.of(right, left), Map.of(), null);
@@ -658,13 +658,13 @@ public class GlobalBuiltins {
                                     return PythonLikeTuple.fromList(List.of(divResult, modResult));
                                 } else {
                                     throw new TypeError(
-                                            "Unsupported operands for divmod: " + left.__getType() + ", " + right.__getType());
+                                            "Unsupported operands for divmod: " + left.$getType() + ", " + right.$getType());
                                 }
                             }
                         }
                     } else {
-                        maybeDiv = right.__getType().__getAttributeOrNull("__rfloordiv__");
-                        maybeMod = right.__getType().__getAttributeOrNull("__rmod__");
+                        maybeDiv = right.$getType().$getAttributeOrNull("__rfloordiv__");
+                        maybeMod = right.$getType().$getAttributeOrNull("__rmod__");
 
                         if (maybeDiv != null && maybeMod != null) {
                             PythonLikeObject divResult =
@@ -675,22 +675,22 @@ public class GlobalBuiltins {
                                 return PythonLikeTuple.fromList(List.of(divResult, modResult));
                             } else {
                                 throw new TypeError(
-                                        "Unsupported operands for divmod: " + left.__getType() + ", " + right.__getType());
+                                        "Unsupported operands for divmod: " + left.$getType() + ", " + right.$getType());
                             }
                         }
                     }
                 }
             } else {
-                PythonLikeObject maybeDiv = left.__getType().__getAttributeOrNull("__floordiv__");
-                PythonLikeObject maybeMod = left.__getType().__getAttributeOrNull("__mod__");
+                PythonLikeObject maybeDiv = left.$getType().$getAttributeOrNull("__floordiv__");
+                PythonLikeObject maybeMod = left.$getType().$getAttributeOrNull("__mod__");
                 if (maybeDiv != null && maybeMod != null) {
                     PythonLikeObject divResult = ((PythonLikeFunction) maybeDiv).$call(List.of(left, right), Map.of(), null);
                     PythonLikeObject modResult = ((PythonLikeFunction) maybeMod).$call(List.of(left, right), Map.of(), null);
                     if (divResult != NotImplemented.INSTANCE && modResult != NotImplemented.INSTANCE) {
                         return PythonLikeTuple.fromList(List.of(divResult, modResult));
                     } else {
-                        maybeDiv = right.__getType().__getAttributeOrNull("__rfloordiv__");
-                        maybeMod = right.__getType().__getAttributeOrNull("__rmod__");
+                        maybeDiv = right.$getType().$getAttributeOrNull("__rfloordiv__");
+                        maybeMod = right.$getType().$getAttributeOrNull("__rmod__");
 
                         if (maybeDiv != null && maybeMod != null) {
                             divResult = ((PythonLikeFunction) maybeDiv).$call(List.of(right, left), Map.of(), null);
@@ -699,13 +699,13 @@ public class GlobalBuiltins {
                                 return PythonLikeTuple.fromList(List.of(divResult, modResult));
                             } else {
                                 throw new TypeError(
-                                        "Unsupported operands for divmod: " + left.__getType() + ", " + right.__getType());
+                                        "Unsupported operands for divmod: " + left.$getType() + ", " + right.$getType());
                             }
                         }
                     }
                 } else {
-                    maybeDiv = right.__getType().__getAttributeOrNull("__rfloordiv__");
-                    maybeMod = right.__getType().__getAttributeOrNull("__rmod__");
+                    maybeDiv = right.$getType().$getAttributeOrNull("__rfloordiv__");
+                    maybeMod = right.$getType().$getAttributeOrNull("__rmod__");
 
                     if (maybeDiv != null && maybeMod != null) {
                         PythonLikeObject divResult =
@@ -716,7 +716,7 @@ public class GlobalBuiltins {
                             return PythonLikeTuple.fromList(List.of(divResult, modResult));
                         } else {
                             throw new TypeError(
-                                    "Unsupported operands for divmod: " + left.__getType() + ", " + right.__getType());
+                                    "Unsupported operands for divmod: " + left.$getType() + ", " + right.$getType());
                         }
                     }
                 }
@@ -895,7 +895,7 @@ public class GlobalBuiltins {
             throw new ValueError("getattr expects 2 or 3 arguments, got " + positionalArgs.size());
         }
 
-        PythonLikeFunction getAttribute = (PythonLikeFunction) object.__getType().__getAttributeOrError("__getattribute__");
+        PythonLikeFunction getAttribute = (PythonLikeFunction) object.$getType().$getAttributeOrError("__getattribute__");
 
         try {
             return getAttribute.$call(List.of(object, name), Map.of(), null);
@@ -1048,20 +1048,20 @@ public class GlobalBuiltins {
 
         if (positionalArgs.size() == 2) {
             if (!(positionalArgs.get(0) instanceof PythonLikeType)) {
-                throw new TypeError("issubclass argument 0 must be a class, not " + positionalArgs.get(0).__getType());
+                throw new TypeError("issubclass argument 0 must be a class, not " + positionalArgs.get(0).$getType());
             }
             type = (PythonLikeType) positionalArgs.get(0);
             classInfo = positionalArgs.get(1);
         } else if (positionalArgs.size() == 1 && keywordArgs.containsKey(PythonString.valueOf("classinfo"))) {
             if (!(positionalArgs.get(0) instanceof PythonLikeType)) {
-                throw new TypeError("issubclass argument 0 must be a class, not " + positionalArgs.get(0).__getType());
+                throw new TypeError("issubclass argument 0 must be a class, not " + positionalArgs.get(0).$getType());
             }
             type = (PythonLikeType) positionalArgs.get(0);
             classInfo = keywordArgs.get(PythonString.valueOf("classinfo"));
         } else if (positionalArgs.size() == 0 && keywordArgs.containsKey(PythonString.valueOf("class"))
                 && keywordArgs.containsKey(PythonString.valueOf("classinfo"))) {
             if (!(keywordArgs.get(PythonString.valueOf("class")) instanceof PythonLikeType)) {
-                throw new TypeError("issubclass argument 0 must be a class, not " + positionalArgs.get(0).__getType());
+                throw new TypeError("issubclass argument 0 must be a class, not " + positionalArgs.get(0).$getType());
             }
             type = (PythonLikeType) keywordArgs.get(PythonString.valueOf("class"));
             classInfo = keywordArgs.get(PythonString.valueOf("classinfo"));
@@ -1154,8 +1154,8 @@ public class GlobalBuiltins {
             }
             return defaultValue;
         } else if (positionalArgs.size() == 1) {
-            Iterator<Comparable> iterator = (Iterator<Comparable>) ((PythonLikeFunction) (positionalArgs.get(0).__getType()
-                    .__getAttributeOrError("__iter__"))).$call(List.of(positionalArgs.get(0)),
+            Iterator<Comparable> iterator = (Iterator<Comparable>) ((PythonLikeFunction) (positionalArgs.get(0).$getType()
+                    .$getAttributeOrError("__iter__"))).$call(List.of(positionalArgs.get(0)),
                             Map.of(), null);
             Comparable min = null;
             for (Iterator<Comparable> it = iterator; it.hasNext();) {
@@ -1198,8 +1198,8 @@ public class GlobalBuiltins {
             }
             return defaultValue;
         } else if (positionalArgs.size() == 1) {
-            Iterator<Comparable> iterator = (Iterator<Comparable>) ((PythonLikeFunction) (positionalArgs.get(0).__getType()
-                    .__getAttributeOrError("__iter__"))).$call(List.of(positionalArgs.get(0)),
+            Iterator<Comparable> iterator = (Iterator<Comparable>) ((PythonLikeFunction) (positionalArgs.get(0).$getType()
+                    .$getAttributeOrError("__iter__"))).$call(List.of(positionalArgs.get(0)),
                             Map.of(), null);
             Comparable max = null;
             for (Iterator<Comparable> it = iterator; it.hasNext();) {
@@ -1371,13 +1371,13 @@ public class GlobalBuiltins {
         }
 
         sequence = positionalArgs.get(0);
-        PythonLikeType sequenceType = sequence.__getType();
-        if (sequenceType.__getAttributeOrNull(PythonUnaryOperator.REVERSED.getDunderMethod()) != null) {
+        PythonLikeType sequenceType = sequence.$getType();
+        if (sequenceType.$getAttributeOrNull(PythonUnaryOperator.REVERSED.getDunderMethod()) != null) {
             return UnaryDunderBuiltin.REVERSED.invoke(sequence);
         }
 
-        if (sequenceType.__getAttributeOrNull(PythonUnaryOperator.LENGTH.getDunderMethod()) != null &&
-                sequenceType.__getAttributeOrNull(PythonBinaryOperator.GET_ITEM.getDunderMethod()) != null) {
+        if (sequenceType.$getAttributeOrNull(PythonUnaryOperator.LENGTH.getDunderMethod()) != null &&
+                sequenceType.$getAttributeOrNull(PythonBinaryOperator.GET_ITEM.getDunderMethod()) != null) {
             PythonInteger length = (PythonInteger) UnaryDunderBuiltin.LENGTH.invoke(sequence);
             Iterator<PythonLikeObject> reversedIterator = new Iterator<>() {
                 PythonInteger current = length.subtract(PythonInteger.ONE);
@@ -1408,9 +1408,9 @@ public class GlobalBuiltins {
         }
 
         PythonLikeObject number = positionalArgs.get(0);
-        PythonLikeType numberType = number.__getType();
-        if (numberType.__getAttributeOrNull("__round__") != null) {
-            return ((PythonLikeFunction) numberType.__getAttributeOrNull("__round__")).$call(positionalArgs, keywordArgs, null);
+        PythonLikeType numberType = number.$getType();
+        if (numberType.$getAttributeOrNull("__round__") != null) {
+            return ((PythonLikeFunction) numberType.$getAttributeOrNull("__round__")).$call(positionalArgs, keywordArgs, null);
         }
 
         throw new ValueError(numberType + " does not has a __round__ method");
@@ -1566,7 +1566,7 @@ public class GlobalBuiltins {
             throw new ValueError("0-argument version of vars is not supported when executed in Java bytecode");
         }
 
-        return positionalArgs.get(0).__getAttributeOrError("__dict__");
+        return positionalArgs.get(0).$getAttributeOrError("__dict__");
     }
 
     public static PythonIterator zip(List<PythonLikeObject> positionalArgs,

--- a/jpyinterpreter/src/main/java/ai/timefold/jpyinterpreter/builtins/TernaryDunderBuiltin.java
+++ b/jpyinterpreter/src/main/java/ai/timefold/jpyinterpreter/builtins/TernaryDunderBuiltin.java
@@ -34,12 +34,12 @@ public class TernaryDunderBuiltin implements PythonLikeFunction {
         PythonLikeObject object = positionalArguments.get(0);
         PythonLikeObject arg1 = positionalArguments.get(1);
         PythonLikeObject arg2 = positionalArguments.get(2);
-        PythonLikeFunction dunderMethod = (PythonLikeFunction) object.__getType().__getAttributeOrError(DUNDER_METHOD_NAME);
+        PythonLikeFunction dunderMethod = (PythonLikeFunction) object.$getType().$getAttributeOrError(DUNDER_METHOD_NAME);
         return dunderMethod.$call(List.of(object, arg1, arg2), Map.of(), null);
     }
 
     public PythonLikeObject invoke(PythonLikeObject object, PythonLikeObject arg1, PythonLikeObject arg2) {
-        PythonLikeFunction dunderMethod = (PythonLikeFunction) object.__getType().__getAttributeOrError(DUNDER_METHOD_NAME);
+        PythonLikeFunction dunderMethod = (PythonLikeFunction) object.$getType().$getAttributeOrError(DUNDER_METHOD_NAME);
         return dunderMethod.$call(List.of(object, arg1, arg2), Map.of(), null);
     }
 }

--- a/jpyinterpreter/src/main/java/ai/timefold/jpyinterpreter/builtins/UnaryDunderBuiltin.java
+++ b/jpyinterpreter/src/main/java/ai/timefold/jpyinterpreter/builtins/UnaryDunderBuiltin.java
@@ -39,12 +39,12 @@ public class UnaryDunderBuiltin implements PythonLikeFunction {
             throw new ValueError("Function " + DUNDER_METHOD_NAME + " expects 1 positional argument");
         }
         PythonLikeObject object = positionalArguments.get(0);
-        PythonLikeFunction dunderMethod = (PythonLikeFunction) object.__getType().__getAttributeOrError(DUNDER_METHOD_NAME);
+        PythonLikeFunction dunderMethod = (PythonLikeFunction) object.$getType().$getAttributeOrError(DUNDER_METHOD_NAME);
         return dunderMethod.$call(List.of(object), Map.of(), null);
     }
 
     public PythonLikeObject invoke(PythonLikeObject object) {
-        PythonLikeFunction dunderMethod = (PythonLikeFunction) object.__getType().__getAttributeOrError(DUNDER_METHOD_NAME);
+        PythonLikeFunction dunderMethod = (PythonLikeFunction) object.$getType().$getAttributeOrError(DUNDER_METHOD_NAME);
         return dunderMethod.$call(List.of(object), Map.of(), null);
     }
 }

--- a/jpyinterpreter/src/main/java/ai/timefold/jpyinterpreter/implementors/DunderOperatorImplementor.java
+++ b/jpyinterpreter/src/main/java/ai/timefold/jpyinterpreter/implementors/DunderOperatorImplementor.java
@@ -62,7 +62,7 @@ public class DunderOperatorImplementor {
      *
      * <code>
      * <pre>
-     *    BiFunction[List, Map, Result] operand_method = TOS.__getType().__getAttributeOrError(operator.getDunderMethod());
+     *    BiFunction[List, Map, Result] operand_method = TOS.$getType().$getAttributeOrError(operator.getDunderMethod());
      *    List args = new ArrayList(1);
      *    args.set(0) = TOS
      *    pop TOS
@@ -74,11 +74,11 @@ public class DunderOperatorImplementor {
     public static void unaryOperator(MethodVisitor methodVisitor, PythonUnaryOperator operator) {
         methodVisitor.visitInsn(Opcodes.DUP);
         methodVisitor.visitMethodInsn(Opcodes.INVOKEINTERFACE, Type.getInternalName(PythonLikeObject.class),
-                "__getType", Type.getMethodDescriptor(Type.getType(PythonLikeType.class)),
+                "$getType", Type.getMethodDescriptor(Type.getType(PythonLikeType.class)),
                 true);
         methodVisitor.visitLdcInsn(operator.getDunderMethod());
         methodVisitor.visitMethodInsn(Opcodes.INVOKEINTERFACE, Type.getInternalName(PythonLikeObject.class),
-                "__getAttributeOrError", Type.getMethodDescriptor(Type.getType(PythonLikeObject.class),
+                "$getAttributeOrError", Type.getMethodDescriptor(Type.getType(PythonLikeObject.class),
                         Type.getType(String.class)),
                 true);
 
@@ -257,7 +257,7 @@ public class DunderOperatorImplementor {
                     false);
             localVariableHelper.readTemp(methodVisitor, Type.getType(PythonLikeObject.class), left);
             methodVisitor.visitMethodInsn(Opcodes.INVOKEINTERFACE, Type.getInternalName(PythonLikeObject.class),
-                    "__getType", Type.getMethodDescriptor(Type.getType(PythonLikeType.class)),
+                    "$getType", Type.getMethodDescriptor(Type.getType(PythonLikeType.class)),
                     true);
             methodVisitor.visitMethodInsn(Opcodes.INVOKEVIRTUAL, Type.getInternalName(PythonLikeType.class),
                     "getTypeName", Type.getMethodDescriptor(Type.getType(String.class)),
@@ -273,7 +273,7 @@ public class DunderOperatorImplementor {
                     false);
             localVariableHelper.readTemp(methodVisitor, Type.getType(PythonLikeObject.class), right);
             methodVisitor.visitMethodInsn(Opcodes.INVOKEINTERFACE, Type.getInternalName(PythonLikeObject.class),
-                    "__getType", Type.getMethodDescriptor(Type.getType(PythonLikeType.class)),
+                    "$getType", Type.getMethodDescriptor(Type.getType(PythonLikeType.class)),
                     true);
             methodVisitor.visitMethodInsn(Opcodes.INVOKEVIRTUAL, Type.getInternalName(PythonLikeType.class),
                     "getTypeName", Type.getMethodDescriptor(Type.getType(String.class)),
@@ -320,7 +320,7 @@ public class DunderOperatorImplementor {
      *
      * <code>
      * <pre>
-     *    BiFunction[List, Map, Result] operand_method = TOS1.__getType().__getAttributeOrError(operator.getDunderMethod());
+     *    BiFunction[List, Map, Result] operand_method = TOS1.$getType().$getAttributeOrError(operator.getDunderMethod());
      *    List args = new ArrayList(2);
      *    args.set(0) = TOS1
      *    args.set(1) = TOS
@@ -342,11 +342,11 @@ public class DunderOperatorImplementor {
         // Stack is now (TOS1, TOS,)? TOS, TOS1
         methodVisitor.visitInsn(Opcodes.DUP);
         methodVisitor.visitMethodInsn(Opcodes.INVOKEINTERFACE, Type.getInternalName(PythonLikeObject.class),
-                "__getType", Type.getMethodDescriptor(Type.getType(PythonLikeType.class)),
+                "$getType", Type.getMethodDescriptor(Type.getType(PythonLikeType.class)),
                 true);
         methodVisitor.visitLdcInsn(operator.getDunderMethod());
         methodVisitor.visitMethodInsn(Opcodes.INVOKEINTERFACE, Type.getInternalName(PythonLikeObject.class),
-                "__getAttributeOrNull", Type.getMethodDescriptor(Type.getType(PythonLikeObject.class),
+                "$getAttributeOrNull", Type.getMethodDescriptor(Type.getType(PythonLikeObject.class),
                         Type.getType(String.class)),
                 true);
         methodVisitor.visitInsn(Opcodes.DUP);
@@ -410,11 +410,11 @@ public class DunderOperatorImplementor {
             // Stack is now TOS1, TOS
             methodVisitor.visitInsn(Opcodes.DUP);
             methodVisitor.visitMethodInsn(Opcodes.INVOKEINTERFACE, Type.getInternalName(PythonLikeObject.class),
-                    "__getType", Type.getMethodDescriptor(Type.getType(PythonLikeType.class)),
+                    "$getType", Type.getMethodDescriptor(Type.getType(PythonLikeType.class)),
                     true);
             methodVisitor.visitLdcInsn(operator.getRightDunderMethod());
             methodVisitor.visitMethodInsn(Opcodes.INVOKEINTERFACE, Type.getInternalName(PythonLikeObject.class),
-                    "__getAttributeOrNull", Type.getMethodDescriptor(Type.getType(PythonLikeObject.class),
+                    "$getAttributeOrNull", Type.getMethodDescriptor(Type.getType(PythonLikeObject.class),
                             Type.getType(String.class)),
                     true);
             methodVisitor.visitInsn(Opcodes.DUP);
@@ -482,11 +482,11 @@ public class DunderOperatorImplementor {
         // Stack is now TOS1, TOS
         methodVisitor.visitInsn(Opcodes.DUP);
         methodVisitor.visitMethodInsn(Opcodes.INVOKEINTERFACE, Type.getInternalName(PythonLikeObject.class),
-                "__getType", Type.getMethodDescriptor(Type.getType(PythonLikeType.class)),
+                "$getType", Type.getMethodDescriptor(Type.getType(PythonLikeType.class)),
                 true);
         methodVisitor.visitLdcInsn(operator.getRightDunderMethod());
         methodVisitor.visitMethodInsn(Opcodes.INVOKEINTERFACE, Type.getInternalName(PythonLikeObject.class),
-                "__getAttributeOrNull", Type.getMethodDescriptor(Type.getType(PythonLikeObject.class),
+                "$getAttributeOrNull", Type.getMethodDescriptor(Type.getType(PythonLikeObject.class),
                         Type.getType(String.class)),
                 true);
         methodVisitor.visitInsn(Opcodes.DUP);
@@ -548,7 +548,7 @@ public class DunderOperatorImplementor {
      *
      * <code>
      * <pre>
-     *    BiFunction[List, Map, Result] operand_method = TOS2.__getType().__getAttributeOrError(operator.getDunderMethod());
+     *    BiFunction[List, Map, Result] operand_method = TOS2.$getType().$getAttributeOrError(operator.getDunderMethod());
      *    List args = new ArrayList(2);
      *    args.set(0) = TOS2
      *    args.set(1) = TOS1
@@ -568,11 +568,11 @@ public class DunderOperatorImplementor {
         // Stack is now TOS, TOS1, TOS2
         methodVisitor.visitInsn(Opcodes.DUP);
         methodVisitor.visitMethodInsn(Opcodes.INVOKEINTERFACE, Type.getInternalName(PythonLikeObject.class),
-                "__getType", Type.getMethodDescriptor(Type.getType(PythonLikeType.class)),
+                "$getType", Type.getMethodDescriptor(Type.getType(PythonLikeType.class)),
                 true);
         methodVisitor.visitLdcInsn(operator.getDunderMethod());
         methodVisitor.visitMethodInsn(Opcodes.INVOKEINTERFACE, Type.getInternalName(PythonLikeObject.class),
-                "__getAttributeOrError", Type.getMethodDescriptor(Type.getType(PythonLikeObject.class),
+                "$getAttributeOrError", Type.getMethodDescriptor(Type.getType(PythonLikeObject.class),
                         Type.getType(String.class)),
                 true);
         // Stack is now TOS, TOS1, TOS2, method
@@ -669,7 +669,7 @@ public class DunderOperatorImplementor {
         methodVisitor.visitInsn(Opcodes.DUP_X1);
 
         methodVisitor.visitMethodInsn(Opcodes.INVOKEINTERFACE, Type.getInternalName(PythonLikeObject.class),
-                "__getType", Type.getMethodDescriptor(Type.getType(PythonLikeType.class)),
+                "$getType", Type.getMethodDescriptor(Type.getType(PythonLikeType.class)),
                 true);
         methodVisitor.visitLdcInsn(operator.getDunderMethod());
         methodVisitor.visitMethodInsn(Opcodes.INVOKEVIRTUAL, Type.getInternalName(PythonLikeType.class),

--- a/jpyinterpreter/src/main/java/ai/timefold/jpyinterpreter/implementors/ExceptionImplementor.java
+++ b/jpyinterpreter/src/main/java/ai/timefold/jpyinterpreter/implementors/ExceptionImplementor.java
@@ -221,7 +221,7 @@ public class ExceptionImplementor {
             // Get exception class
             methodVisitor.visitInsn(Opcodes.DUP);
             methodVisitor.visitMethodInsn(Opcodes.INVOKEINTERFACE, Type.getInternalName(PythonLikeObject.class),
-                    "__getType", Type.getMethodDescriptor(Type.getType(PythonLikeType.class)),
+                    "$getType", Type.getMethodDescriptor(Type.getType(PythonLikeType.class)),
                     true);
 
             // Stack is (stack-before-try), instruction, stack-size, label, traceback, exception, exception_class
@@ -255,11 +255,11 @@ public class ExceptionImplementor {
 
         // First load the method __exit__
         methodVisitor.visitMethodInsn(Opcodes.INVOKEINTERFACE, Type.getInternalName(PythonLikeObject.class),
-                "__getType", Type.getMethodDescriptor(Type.getType(PythonLikeType.class)),
+                "$getType", Type.getMethodDescriptor(Type.getType(PythonLikeType.class)),
                 true);
         methodVisitor.visitLdcInsn("__exit__");
         methodVisitor.visitMethodInsn(Opcodes.INVOKEINTERFACE, Type.getInternalName(PythonLikeObject.class),
-                "__getAttributeOrError",
+                "$getAttributeOrError",
                 Type.getMethodDescriptor(Type.getType(PythonLikeObject.class), Type.getType(String.class)),
                 true);
         methodVisitor.visitTypeInsn(Opcodes.CHECKCAST, Type.getInternalName(PythonLikeFunction.class));

--- a/jpyinterpreter/src/main/java/ai/timefold/jpyinterpreter/implementors/FunctionImplementor.java
+++ b/jpyinterpreter/src/main/java/ai/timefold/jpyinterpreter/implementors/FunctionImplementor.java
@@ -43,11 +43,11 @@ public class FunctionImplementor {
         methodVisitor.visitInsn(Opcodes.SWAP);
         methodVisitor.visitInsn(Opcodes.DUP);
         methodVisitor.visitMethodInsn(Opcodes.INVOKEINTERFACE, Type.getInternalName(PythonLikeObject.class),
-                "__getType", Type.getMethodDescriptor(Type.getType(PythonLikeType.class)),
+                "$getType", Type.getMethodDescriptor(Type.getType(PythonLikeType.class)),
                 true);
         methodVisitor.visitLdcInsn(methodName);
         methodVisitor.visitMethodInsn(Opcodes.INVOKEINTERFACE, Type.getInternalName(PythonLikeObject.class),
-                "__getAttributeOrError", Type.getMethodDescriptor(Type.getType(PythonLikeObject.class),
+                "$getAttributeOrError", Type.getMethodDescriptor(Type.getType(PythonLikeObject.class),
                         Type.getType(String.class)),
                 true);
         methodVisitor.visitInsn(Opcodes.DUP_X2);
@@ -71,11 +71,11 @@ public class FunctionImplementor {
         methodVisitor.visitInsn(Opcodes.SWAP);
         methodVisitor.visitInsn(Opcodes.DUP);
         methodVisitor.visitMethodInsn(Opcodes.INVOKEINTERFACE, Type.getInternalName(PythonLikeObject.class),
-                "__getType", Type.getMethodDescriptor(Type.getType(PythonLikeType.class)),
+                "$getType", Type.getMethodDescriptor(Type.getType(PythonLikeType.class)),
                 true);
         methodVisitor.visitLdcInsn(methodName);
         methodVisitor.visitMethodInsn(Opcodes.INVOKEINTERFACE, Type.getInternalName(PythonLikeObject.class),
-                "__getAttributeOrError", Type.getMethodDescriptor(Type.getType(PythonLikeObject.class),
+                "$getAttributeOrError", Type.getMethodDescriptor(Type.getType(PythonLikeObject.class),
                         Type.getType(String.class)),
                 true);
         methodVisitor.visitInsn(Opcodes.DUP_X2);
@@ -119,7 +119,7 @@ public class FunctionImplementor {
                     if (isTosType && knownFunctionType.isStaticMethod()) {
                         methodVisitor.visitLdcInsn(function.co_names.get(instruction.arg));
                         methodVisitor.visitMethodInsn(Opcodes.INVOKEINTERFACE, Type.getInternalName(PythonLikeObject.class),
-                                "__getAttributeOrNull", Type.getMethodDescriptor(Type.getType(PythonLikeObject.class),
+                                "$getAttributeOrNull", Type.getMethodDescriptor(Type.getType(PythonLikeObject.class),
                                         Type.getType(String.class)),
                                 true);
 
@@ -131,11 +131,11 @@ public class FunctionImplementor {
                         }
                     } else if (!isTosType && knownFunctionType.isStaticMethod()) {
                         methodVisitor.visitMethodInsn(Opcodes.INVOKEINTERFACE, Type.getInternalName(PythonLikeObject.class),
-                                "__getType", Type.getMethodDescriptor(Type.getType(PythonLikeType.class)),
+                                "$getType", Type.getMethodDescriptor(Type.getType(PythonLikeType.class)),
                                 true);
                         methodVisitor.visitLdcInsn(function.co_names.get(instruction.arg));
                         methodVisitor.visitMethodInsn(Opcodes.INVOKEINTERFACE, Type.getInternalName(PythonLikeObject.class),
-                                "__getAttributeOrNull", Type.getMethodDescriptor(Type.getType(PythonLikeObject.class),
+                                "$getAttributeOrNull", Type.getMethodDescriptor(Type.getType(PythonLikeObject.class),
                                         Type.getType(String.class)),
                                 true);
                         methodVisitor.visitInsn(Opcodes.ACONST_NULL);
@@ -148,18 +148,18 @@ public class FunctionImplementor {
                         methodVisitor.visitInsn(Opcodes.DUP);
                         methodVisitor.visitLdcInsn(function.co_names.get(instruction.arg));
                         methodVisitor.visitMethodInsn(Opcodes.INVOKEINTERFACE, Type.getInternalName(PythonLikeObject.class),
-                                "__getAttributeOrNull", Type.getMethodDescriptor(Type.getType(PythonLikeObject.class),
+                                "$getAttributeOrNull", Type.getMethodDescriptor(Type.getType(PythonLikeObject.class),
                                         Type.getType(String.class)),
                                 true);
                         methodVisitor.visitInsn(Opcodes.SWAP);
                     } else if (!isTosType && knownFunctionType.isClassMethod()) {
                         methodVisitor.visitInsn(Opcodes.DUP);
                         methodVisitor.visitMethodInsn(Opcodes.INVOKEINTERFACE, Type.getInternalName(PythonLikeObject.class),
-                                "__getType", Type.getMethodDescriptor(Type.getType(PythonLikeType.class)),
+                                "$getType", Type.getMethodDescriptor(Type.getType(PythonLikeType.class)),
                                 true);
                         methodVisitor.visitLdcInsn(function.co_names.get(instruction.arg));
                         methodVisitor.visitMethodInsn(Opcodes.INVOKEINTERFACE, Type.getInternalName(PythonLikeObject.class),
-                                "__getAttributeOrNull", Type.getMethodDescriptor(Type.getType(PythonLikeObject.class),
+                                "$getAttributeOrNull", Type.getMethodDescriptor(Type.getType(PythonLikeObject.class),
                                         Type.getType(String.class)),
                                 true);
                         methodVisitor.visitInsn(Opcodes.SWAP);
@@ -167,18 +167,18 @@ public class FunctionImplementor {
                         methodVisitor.visitInsn(Opcodes.DUP);
                         methodVisitor.visitLdcInsn(function.co_names.get(instruction.arg));
                         methodVisitor.visitMethodInsn(Opcodes.INVOKEINTERFACE, Type.getInternalName(PythonLikeObject.class),
-                                "__getAttributeOrNull", Type.getMethodDescriptor(Type.getType(PythonLikeObject.class),
+                                "$getAttributeOrNull", Type.getMethodDescriptor(Type.getType(PythonLikeObject.class),
                                         Type.getType(String.class)),
                                 true);
                         methodVisitor.visitInsn(Opcodes.SWAP);
                     } else {
                         methodVisitor.visitInsn(Opcodes.DUP);
                         methodVisitor.visitMethodInsn(Opcodes.INVOKEINTERFACE, Type.getInternalName(PythonLikeObject.class),
-                                "__getType", Type.getMethodDescriptor(Type.getType(PythonLikeType.class)),
+                                "$getType", Type.getMethodDescriptor(Type.getType(PythonLikeType.class)),
                                 true);
                         methodVisitor.visitLdcInsn(function.co_names.get(instruction.arg));
                         methodVisitor.visitMethodInsn(Opcodes.INVOKEINTERFACE, Type.getInternalName(PythonLikeObject.class),
-                                "__getAttributeOrNull", Type.getMethodDescriptor(Type.getType(PythonLikeObject.class),
+                                "$getAttributeOrNull", Type.getMethodDescriptor(Type.getType(PythonLikeObject.class),
                                         Type.getType(String.class)),
                                 true);
                         methodVisitor.visitInsn(Opcodes.SWAP);
@@ -199,7 +199,7 @@ public class FunctionImplementor {
 
         methodVisitor.visitInsn(Opcodes.DUP);
         methodVisitor.visitMethodInsn(Opcodes.INVOKEINTERFACE, Type.getInternalName(PythonLikeObject.class),
-                "__getType", Type.getMethodDescriptor(Type.getType(PythonLikeType.class)),
+                "$getType", Type.getMethodDescriptor(Type.getType(PythonLikeType.class)),
                 true);
         methodVisitor.visitLdcInsn(function.co_names.get(instruction.arg));
         methodVisitor.visitMethodInsn(Opcodes.INVOKEVIRTUAL, Type.getInternalName(PythonLikeType.class),

--- a/jpyinterpreter/src/main/java/ai/timefold/jpyinterpreter/implementors/GeneratorImplementor.java
+++ b/jpyinterpreter/src/main/java/ai/timefold/jpyinterpreter/implementors/GeneratorImplementor.java
@@ -256,12 +256,12 @@ public class GeneratorImplementor {
                             methodVisitor.visitInsn(Opcodes.DUP);
                             methodVisitor.visitMethodInsn(Opcodes.INVOKEINTERFACE,
                                     Type.getInternalName(PythonLikeObject.class),
-                                    "__getType", Type.getMethodDescriptor(Type.getType(PythonLikeType.class)),
+                                    "$getType", Type.getMethodDescriptor(Type.getType(PythonLikeType.class)),
                                     true);
                             methodVisitor.visitLdcInsn("throw");
                             methodVisitor.visitMethodInsn(Opcodes.INVOKEINTERFACE,
                                     Type.getInternalName(PythonLikeObject.class),
-                                    "__getAttributeOrNull",
+                                    "$getAttributeOrNull",
                                     Type.getMethodDescriptor(Type.getType(PythonLikeObject.class),
                                             Type.getType(String.class)),
                                     true);

--- a/jpyinterpreter/src/main/java/ai/timefold/jpyinterpreter/implementors/KnownCallImplementor.java
+++ b/jpyinterpreter/src/main/java/ai/timefold/jpyinterpreter/implementors/KnownCallImplementor.java
@@ -98,7 +98,7 @@ public class KnownCallImplementor {
             methodVisitor.visitTypeInsn(Opcodes.INSTANCEOF, Type.getInternalName(PythonLikeType.class));
             methodVisitor.visitJumpInsn(Opcodes.IFNE, doneGettingType);
             methodVisitor.visitMethodInsn(Opcodes.INVOKEINTERFACE, Type.getInternalName(PythonLikeObject.class),
-                    "__getType", Type.getMethodDescriptor(Type.getType(PythonLikeType.class)),
+                    "$getType", Type.getMethodDescriptor(Type.getType(PythonLikeType.class)),
                     true);
             methodVisitor.visitJumpInsn(Opcodes.GOTO, doneGettingType);
             methodVisitor.visitLabel(ifIsBoundFunction);
@@ -264,7 +264,7 @@ public class KnownCallImplementor {
             methodVisitor.visitTypeInsn(Opcodes.INSTANCEOF, Type.getInternalName(PythonLikeType.class));
             methodVisitor.visitJumpInsn(Opcodes.IFNE, doneGettingType);
             methodVisitor.visitMethodInsn(Opcodes.INVOKEINTERFACE, Type.getInternalName(PythonLikeObject.class),
-                    "__getType", Type.getMethodDescriptor(Type.getType(PythonLikeType.class)),
+                    "$getType", Type.getMethodDescriptor(Type.getType(PythonLikeType.class)),
                     true);
             methodVisitor.visitJumpInsn(Opcodes.GOTO, doneGettingType);
             methodVisitor.visitLabel(ifIsBoundFunction);
@@ -379,7 +379,7 @@ public class KnownCallImplementor {
                 methodVisitor.visitTypeInsn(Opcodes.INSTANCEOF, Type.getInternalName(PythonLikeType.class));
                 methodVisitor.visitJumpInsn(Opcodes.IFNE, doneGettingType);
                 methodVisitor.visitMethodInsn(Opcodes.INVOKEINTERFACE, Type.getInternalName(PythonLikeObject.class),
-                        "__getType", Type.getMethodDescriptor(Type.getType(PythonLikeType.class)),
+                        "$getType", Type.getMethodDescriptor(Type.getType(PythonLikeType.class)),
                         true);
                 methodVisitor.visitJumpInsn(Opcodes.GOTO, doneGettingType);
                 methodVisitor.visitLabel(ifIsBoundFunction);

--- a/jpyinterpreter/src/main/java/ai/timefold/jpyinterpreter/implementors/ModuleImplementor.java
+++ b/jpyinterpreter/src/main/java/ai/timefold/jpyinterpreter/implementors/ModuleImplementor.java
@@ -120,7 +120,7 @@ public class ModuleImplementor {
 
         // Get the attribute
         methodVisitor.visitMethodInsn(Opcodes.INVOKEINTERFACE, Type.getInternalName(PythonLikeObject.class),
-                "__getAttributeOrError",
+                "$getAttributeOrError",
                 Type.getMethodDescriptor(Type.getType(PythonLikeObject.class), Type.getType(String.class)),
                 true);
 

--- a/jpyinterpreter/src/main/java/ai/timefold/jpyinterpreter/opcodes/variable/LoadConstantOpcode.java
+++ b/jpyinterpreter/src/main/java/ai/timefold/jpyinterpreter/opcodes/variable/LoadConstantOpcode.java
@@ -20,14 +20,14 @@ public class LoadConstantOpcode extends AbstractOpcode {
     @Override
     protected StackMetadata getStackMetadataAfterInstruction(FunctionMetadata functionMetadata, StackMetadata stackMetadata) {
         PythonLikeObject constant = functionMetadata.pythonCompiledFunction.co_constants.get(instruction.arg);
-        PythonLikeType constantType = constant.__getGenericType();
+        PythonLikeType constantType = constant.$getGenericType();
         return stackMetadata.push(ValueSourceInfo.of(this, constantType));
     }
 
     @Override
     public void implement(FunctionMetadata functionMetadata, StackMetadata stackMetadata) {
         PythonLikeObject constant = functionMetadata.pythonCompiledFunction.co_constants.get(instruction.arg);
-        PythonLikeType constantType = constant.__getGenericType();
+        PythonLikeType constantType = constant.$getGenericType();
 
         PythonConstantsImplementor.loadConstant(functionMetadata.methodVisitor, functionMetadata.className,
                 instruction.arg);

--- a/jpyinterpreter/src/main/java/ai/timefold/jpyinterpreter/opcodes/variable/LoadGlobalOpcode.java
+++ b/jpyinterpreter/src/main/java/ai/timefold/jpyinterpreter/opcodes/variable/LoadGlobalOpcode.java
@@ -45,7 +45,7 @@ public class LoadGlobalOpcode extends AbstractOpcode {
             if (global != null) {
                 return stackMetadata
                         .push(ValueSourceInfo.of(this, BuiltinTypes.NULL_TYPE))
-                        .push(ValueSourceInfo.of(this, global.__getGenericType()));
+                        .push(ValueSourceInfo.of(this, global.$getGenericType()));
             } else {
                 return stackMetadata
                         .push(ValueSourceInfo.of(this, BuiltinTypes.NULL_TYPE))
@@ -54,7 +54,7 @@ public class LoadGlobalOpcode extends AbstractOpcode {
         } else {
             if (global != null) {
                 return stackMetadata
-                        .push(ValueSourceInfo.of(this, global.__getGenericType()));
+                        .push(ValueSourceInfo.of(this, global.$getGenericType()));
             } else {
                 return stackMetadata
                         .push(ValueSourceInfo.of(this, BuiltinTypes.BASE_TYPE));
@@ -77,6 +77,6 @@ public class LoadGlobalOpcode extends AbstractOpcode {
             functionMetadata.methodVisitor.visitInsn(Opcodes.ACONST_NULL);
         }
         VariableImplementor.loadGlobalVariable(functionMetadata, stackMetadata, globalIndex,
-                (global != null) ? global.__getGenericType() : BuiltinTypes.BASE_TYPE);
+                (global != null) ? global.$getGenericType() : BuiltinTypes.BASE_TYPE);
     }
 }

--- a/jpyinterpreter/src/main/java/ai/timefold/jpyinterpreter/types/AbstractPythonLikeObject.java
+++ b/jpyinterpreter/src/main/java/ai/timefold/jpyinterpreter/types/AbstractPythonLikeObject.java
@@ -23,26 +23,26 @@ public abstract class AbstractPythonLikeObject implements PythonLikeObject {
     }
 
     @Override
-    public PythonLikeObject __getAttributeOrNull(String attributeName) {
+    public PythonLikeObject $getAttributeOrNull(String attributeName) {
         return __dir__.get(attributeName);
     }
 
     @Override
-    public void __setAttribute(String attributeName, PythonLikeObject value) {
+    public void $setAttribute(String attributeName, PythonLikeObject value) {
         __dir__.put(attributeName, value);
     }
 
     @Override
-    public void __deleteAttribute(String attributeName) {
+    public void $deleteAttribute(String attributeName) {
         // TODO: Descriptors: https://docs.python.org/3/howto/descriptor.html
         if (!__dir__.containsKey(attributeName)) {
-            throw new AttributeError("'" + __getType().getTypeName() + "' object has no attribute '" + attributeName + "'");
+            throw new AttributeError("'" + $getType().getTypeName() + "' object has no attribute '" + attributeName + "'");
         }
         __dir__.remove(attributeName);
     }
 
     @Override
-    public PythonLikeType __getType() {
+    public PythonLikeType $getType() {
         return __type__;
     }
 

--- a/jpyinterpreter/src/main/java/ai/timefold/jpyinterpreter/types/BoundPythonLikeFunction.java
+++ b/jpyinterpreter/src/main/java/ai/timefold/jpyinterpreter/types/BoundPythonLikeFunction.java
@@ -19,7 +19,7 @@ public class BoundPythonLikeFunction implements PythonLikeFunction {
         if (instance instanceof PythonLikeType) {
             return new BoundPythonLikeFunction(instance, function);
         } else {
-            return new BoundPythonLikeFunction(instance.__getType(), function);
+            return new BoundPythonLikeFunction(instance.$getType(), function);
         }
     }
 

--- a/jpyinterpreter/src/main/java/ai/timefold/jpyinterpreter/types/GeneratedFunctionMethodReference.java
+++ b/jpyinterpreter/src/main/java/ai/timefold/jpyinterpreter/types/GeneratedFunctionMethodReference.java
@@ -56,7 +56,7 @@ public class GeneratedFunctionMethodReference implements PythonLikeFunction {
     }
 
     @Override
-    public PythonLikeType __getType() {
+    public PythonLikeType $getType() {
         return type;
     }
 }

--- a/jpyinterpreter/src/main/java/ai/timefold/jpyinterpreter/types/PythonByteArray.java
+++ b/jpyinterpreter/src/main/java/ai/timefold/jpyinterpreter/types/PythonByteArray.java
@@ -519,7 +519,7 @@ public class PythonByteArray extends AbstractPythonLikeObject implements PythonB
                 PythonLikeObject next = iterator.nextPythonItem();
                 byte[] byteWrapper = new byte[1];
                 if (!(next instanceof PythonInteger)) {
-                    throw new TypeError("'" + next.__getType().getTypeName() + "' object cannot be interpreted as an integer");
+                    throw new TypeError("'" + next.$getType().getTypeName() + "' object cannot be interpreted as an integer");
                 }
                 byteWrapper[0] = ((PythonInteger) next).asByte();
                 out.writeBytes(byteWrapper);
@@ -1038,7 +1038,7 @@ public class PythonByteArray extends AbstractPythonLikeObject implements PythonB
             PythonLikeObject item = iterator.nextPythonItem();
 
             if (!(item instanceof PythonBytesLikeObject)) {
-                throw new TypeError("type " + item.__getType() + " is not a bytes-like type");
+                throw new TypeError("type " + item.$getType() + " is not a bytes-like type");
             }
 
             outputStream.writeBytes(((PythonBytesLikeObject) item).asByteArray());

--- a/jpyinterpreter/src/main/java/ai/timefold/jpyinterpreter/types/PythonBytes.java
+++ b/jpyinterpreter/src/main/java/ai/timefold/jpyinterpreter/types/PythonBytes.java
@@ -844,7 +844,7 @@ public class PythonBytes extends AbstractPythonLikeObject implements PythonBytes
             PythonLikeObject item = iterator.nextPythonItem();
 
             if (!(item instanceof PythonBytesLikeObject)) {
-                throw new TypeError("type " + item.__getType() + " is not a bytes-like type");
+                throw new TypeError("type " + item.$getType() + " is not a bytes-like type");
             }
 
             outputStream.writeBytes(((PythonBytesLikeObject) item).asByteArray());

--- a/jpyinterpreter/src/main/java/ai/timefold/jpyinterpreter/types/PythonKnownFunctionType.java
+++ b/jpyinterpreter/src/main/java/ai/timefold/jpyinterpreter/types/PythonKnownFunctionType.java
@@ -28,12 +28,12 @@ public class PythonKnownFunctionType extends PythonLikeType {
     }
 
     @Override
-    public PythonLikeType __getType() {
+    public PythonLikeType $getType() {
         return BuiltinTypes.BASE_TYPE;
     }
 
     @Override
-    public PythonLikeType __getGenericType() {
+    public PythonLikeType $getGenericType() {
         return BuiltinTypes.BASE_TYPE;
     }
 

--- a/jpyinterpreter/src/main/java/ai/timefold/jpyinterpreter/types/PythonLikeFunction.java
+++ b/jpyinterpreter/src/main/java/ai/timefold/jpyinterpreter/types/PythonLikeFunction.java
@@ -30,22 +30,22 @@ public interface PythonLikeFunction extends PythonLikeObject {
             PythonLikeObject callerInstance);
 
     @Override
-    default PythonLikeObject __getAttributeOrNull(String attributeName) {
+    default PythonLikeObject $getAttributeOrNull(String attributeName) {
         return null;
     }
 
     @Override
-    default void __setAttribute(String attributeName, PythonLikeObject value) {
+    default void $setAttribute(String attributeName, PythonLikeObject value) {
         throw new UnsupportedOperationException();
     }
 
     @Override
-    default void __deleteAttribute(String attributeName) {
+    default void $deleteAttribute(String attributeName) {
         throw new UnsupportedOperationException();
     }
 
     @Override
-    default PythonLikeType __getType() {
+    default PythonLikeType $getType() {
         return BuiltinTypes.FUNCTION_TYPE;
     }
 }

--- a/jpyinterpreter/src/main/java/ai/timefold/jpyinterpreter/types/PythonLikeType.java
+++ b/jpyinterpreter/src/main/java/ai/timefold/jpyinterpreter/types/PythonLikeType.java
@@ -124,7 +124,7 @@ public class PythonLikeType implements PythonLikeObject,
     }
 
     public boolean isInstance(PythonLikeObject object) {
-        PythonLikeType objectType = object.__getType();
+        PythonLikeType objectType = object.$getType();
         return objectType.isSubclassOf(this);
     }
 
@@ -162,7 +162,7 @@ public class PythonLikeType implements PythonLikeObject,
     public static PythonLikeType registerTypeType() {
         BuiltinTypes.TYPE_TYPE.setConstructor((positional, keywords, callerInstance) -> {
             if (positional.size() == 1) {
-                return positional.get(0).__getType();
+                return positional.get(0).$getType();
             } else if (positional.size() == 3) {
                 PythonString name = (PythonString) positional.get(0);
                 PythonLikeTuple baseClasses = (PythonLikeTuple) positional.get(1);
@@ -178,7 +178,7 @@ public class PythonLikeType implements PythonLikeObject,
                 for (Map.Entry<PythonLikeObject, PythonLikeObject> entry : dict.entrySet()) {
                     PythonString attributeName = (PythonString) entry.getKey();
 
-                    out.__setAttribute(attributeName.value, entry.getValue());
+                    out.$setAttribute(attributeName.value, entry.getValue());
                 }
 
                 return out;
@@ -193,16 +193,16 @@ public class PythonLikeType implements PythonLikeObject,
     @Override
     public PythonLikeObject $method$__getattribute__(PythonString pythonName) {
         String name = pythonName.value;
-        PythonLikeObject typeResult = __getAttributeOrNull(name);
+        PythonLikeObject typeResult = this.$getAttributeOrNull(name);
         if (typeResult != null) {
-            PythonLikeObject maybeDescriptor = typeResult.__getAttributeOrNull(PythonTernaryOperator.GET.dunderMethod);
+            PythonLikeObject maybeDescriptor = typeResult.$getAttributeOrNull(PythonTernaryOperator.GET.dunderMethod);
             if (maybeDescriptor == null) {
-                maybeDescriptor = typeResult.__getType().__getAttributeOrNull(PythonTernaryOperator.GET.dunderMethod);
+                maybeDescriptor = typeResult.$getType().$getAttributeOrNull(PythonTernaryOperator.GET.dunderMethod);
             }
 
             if (maybeDescriptor != null) {
                 if (!(maybeDescriptor instanceof PythonLikeFunction)) {
-                    throw new UnsupportedOperationException("'" + maybeDescriptor.__getType() + "' is not callable");
+                    throw new UnsupportedOperationException("'" + maybeDescriptor.$getType() + "' is not callable");
                 }
                 return TernaryDunderBuiltin.GET_DESCRIPTOR.invoke(typeResult, PythonNone.INSTANCE, this);
             }
@@ -312,9 +312,9 @@ public class PythonLikeType implements PythonLikeObject,
     }
 
     public Optional<PythonClassTranslator.PythonMethodKind> getMethodKind(String methodName) {
-        PythonLikeObject maybeMethod = __getAttributeOrNull(methodName);
+        PythonLikeObject maybeMethod = this.$getAttributeOrNull(methodName);
         if (maybeMethod != null) {
-            PythonLikeType methodKind = maybeMethod.__getType();
+            PythonLikeType methodKind = maybeMethod.$getType();
             if (methodKind == BuiltinTypes.FUNCTION_TYPE) {
                 return Optional.of(PythonClassTranslator.PythonMethodKind.VIRTUAL_METHOD);
             }
@@ -450,17 +450,17 @@ public class PythonLikeType implements PythonLikeObject,
     }
 
     public PythonLikeObject loadMethod(String methodName) {
-        PythonLikeObject out = __getAttributeOrNull(methodName);
+        PythonLikeObject out = this.$getAttributeOrNull(methodName);
         if (out == null) {
             return null;
         }
 
-        if (out.__getType() == BuiltinTypes.FUNCTION_TYPE) {
+        if (out.$getType() == BuiltinTypes.FUNCTION_TYPE) {
             return out;
         }
 
         return null;
-        //if (out.__getType() == PythonLikeFunction.getClassFunctionType()) {
+        //if (out.$getType() == PythonLikeFunction.getClassFunctionType()) {
         //    return FunctionBuiltinOperations.bindFunctionToType((PythonLikeFunction) out, null, this);
         //} else {
         //    return null;
@@ -484,11 +484,11 @@ public class PythonLikeType implements PythonLikeObject,
         return null;
     }
 
-    public PythonLikeObject __getAttributeOrNull(String attributeName) {
+    public PythonLikeObject $getAttributeOrNull(String attributeName) {
         PythonLikeObject out = __dir__.get(attributeName);
         if (out == null) {
             for (PythonLikeType type : PARENT_TYPES) {
-                out = type.__getAttributeOrNull(attributeName);
+                out = type.$getAttributeOrNull(attributeName);
                 if (out != null) {
                     return out;
                 }
@@ -500,23 +500,23 @@ public class PythonLikeType implements PythonLikeObject,
     }
 
     @Override
-    public void __setAttribute(String attributeName, PythonLikeObject value) {
+    public void $setAttribute(String attributeName, PythonLikeObject value) {
         __dir__.put(attributeName, value);
     }
 
     @Override
-    public void __deleteAttribute(String attributeName) {
+    public void $deleteAttribute(String attributeName) {
         // TODO: Descriptors: https://docs.python.org/3/howto/descriptor.html
         __dir__.remove(attributeName);
     }
 
     @Override
-    public PythonLikeType __getType() {
+    public PythonLikeType $getType() {
         return BuiltinTypes.TYPE_TYPE;
     }
 
     @Override
-    public PythonLikeType __getGenericType() {
+    public PythonLikeType $getGenericType() {
         return new PythonLikeGenericType(this);
     }
 

--- a/jpyinterpreter/src/main/java/ai/timefold/jpyinterpreter/types/PythonModule.java
+++ b/jpyinterpreter/src/main/java/ai/timefold/jpyinterpreter/types/PythonModule.java
@@ -19,7 +19,7 @@ public class PythonModule extends AbstractPythonLikeObject {
     }
 
     public void addItem(String itemName, PythonLikeObject itemValue) {
-        __setAttribute(itemName, itemValue);
+        $setAttribute(itemName, itemValue);
     }
 
     public OpaquePythonReference getPythonReference() {
@@ -31,12 +31,12 @@ public class PythonModule extends AbstractPythonLikeObject {
     }
 
     @Override
-    public PythonLikeObject __getAttributeOrNull(String attributeName) {
-        PythonLikeObject result = super.__getAttributeOrNull(attributeName);
+    public PythonLikeObject $getAttributeOrNull(String attributeName) {
+        PythonLikeObject result = super.$getAttributeOrNull(attributeName);
         if (result == null) {
             PythonLikeObject actual = CPythonBackedPythonInterpreter.lookupAttributeOnPythonReference(pythonReference,
                     attributeName, referenceMap);
-            __setAttribute(attributeName, actual);
+            $setAttribute(attributeName, actual);
             return actual;
         }
         return result;

--- a/jpyinterpreter/src/main/java/ai/timefold/jpyinterpreter/types/PythonRange.java
+++ b/jpyinterpreter/src/main/java/ai/timefold/jpyinterpreter/types/PythonRange.java
@@ -104,9 +104,9 @@ public class PythonRange extends AbstractPythonLikeObject implements List<Python
         this.stop = stop;
         this.step = step;
 
-        __setAttribute("start", start);
-        __setAttribute("stop", stop);
-        __setAttribute("step", step);
+        $setAttribute("start", start);
+        $setAttribute("stop", stop);
+        $setAttribute("step", step);
     }
 
     @Override

--- a/jpyinterpreter/src/main/java/ai/timefold/jpyinterpreter/types/PythonSlice.java
+++ b/jpyinterpreter/src/main/java/ai/timefold/jpyinterpreter/types/PythonSlice.java
@@ -81,9 +81,9 @@ public class PythonSlice extends AbstractPythonLikeObject {
         this.stop = stop;
         this.step = step;
 
-        __setAttribute("start", (start != null) ? start : PythonNone.INSTANCE);
-        __setAttribute("stop", (stop != null) ? stop : PythonNone.INSTANCE);
-        __setAttribute("step", (step != null) ? step : PythonNone.INSTANCE);
+        $setAttribute("start", (start != null) ? start : PythonNone.INSTANCE);
+        $setAttribute("stop", (stop != null) ? stop : PythonNone.INSTANCE);
+        $setAttribute("step", (step != null) ? step : PythonNone.INSTANCE);
     }
 
     /**

--- a/jpyinterpreter/src/main/java/ai/timefold/jpyinterpreter/types/PythonString.java
+++ b/jpyinterpreter/src/main/java/ai/timefold/jpyinterpreter/types/PythonString.java
@@ -1138,7 +1138,7 @@ public class PythonString extends AbstractPythonLikeObject implements PythonLike
             PythonLikeObject maybeString = iterator.nextPythonItem();
             if (!(maybeString instanceof PythonString)) {
                 throw new TypeError("sequence item " + index + ": expected str instance, "
-                        + maybeString.__getType().getTypeName() + " found");
+                        + maybeString.$getType().getTypeName() + " found");
             }
             PythonString string = (PythonString) maybeString;
             out.append(string.value);

--- a/jpyinterpreter/src/main/java/ai/timefold/jpyinterpreter/types/PythonSuperObject.java
+++ b/jpyinterpreter/src/main/java/ai/timefold/jpyinterpreter/types/PythonSuperObject.java
@@ -34,7 +34,7 @@ public class PythonSuperObject extends AbstractPythonLikeObject {
             if (instance instanceof PythonLikeType) {
                 mro = ((PythonLikeType) instance).MRO;
             } else {
-                mro = instance.__getType().MRO;
+                mro = instance.$getType().MRO;
             }
         } else {
             mro = previousType.MRO;
@@ -44,7 +44,7 @@ public class PythonSuperObject extends AbstractPythonLikeObject {
         for (int currentIndex = mro.indexOf(previousType) + 1; currentIndex < mro.size(); currentIndex++) {
             PythonLikeType candidate = mro.get(currentIndex);
 
-            PythonLikeObject typeResult = candidate.__getAttributeOrNull(name);
+            PythonLikeObject typeResult = candidate.$getAttributeOrNull(name);
             if (typeResult != null) {
 
                 if (typeResult instanceof PythonLikeFunction && !(typeResult instanceof PythonLikeType)) {
@@ -54,20 +54,20 @@ public class PythonSuperObject extends AbstractPythonLikeObject {
                         typeResult = new GeneratedFunctionMethodReference(methodInstance,
                                 methodInstance.getClass().getDeclaredMethods()[0],
                                 Map.of(),
-                                typeResult.__getType());
+                                typeResult.$getType());
                     } catch (ClassNotFoundException | NoSuchFieldException | IllegalAccessException e) {
                         // ignore
                     }
                 }
 
-                PythonLikeObject maybeDescriptor = typeResult.__getAttributeOrNull(PythonTernaryOperator.GET.dunderMethod);
+                PythonLikeObject maybeDescriptor = typeResult.$getAttributeOrNull(PythonTernaryOperator.GET.dunderMethod);
                 if (maybeDescriptor == null) {
-                    maybeDescriptor = typeResult.__getType().__getAttributeOrNull(PythonTernaryOperator.GET.dunderMethod);
+                    maybeDescriptor = typeResult.$getType().$getAttributeOrNull(PythonTernaryOperator.GET.dunderMethod);
                 }
 
                 if (maybeDescriptor != null) {
                     if (!(maybeDescriptor instanceof PythonLikeFunction)) {
-                        throw new UnsupportedOperationException("'" + maybeDescriptor.__getType() + "' is not callable");
+                        throw new UnsupportedOperationException("'" + maybeDescriptor.$getType() + "' is not callable");
                     }
                     return TernaryDunderBuiltin.GET_DESCRIPTOR.invoke(typeResult,
                             (instance != null) ? instance : PythonNone.INSTANCE,

--- a/jpyinterpreter/src/main/java/ai/timefold/jpyinterpreter/types/collections/view/DictItemView.java
+++ b/jpyinterpreter/src/main/java/ai/timefold/jpyinterpreter/types/collections/view/DictItemView.java
@@ -79,7 +79,7 @@ public class DictItemView extends AbstractPythonLikeObject {
         super(BuiltinTypes.DICT_ITEM_VIEW_TYPE);
         this.mapping = mapping;
         this.entrySet = mapping.delegate.entrySet();
-        __setAttribute("mapping", mapping);
+        $setAttribute("mapping", mapping);
     }
 
     private List<PythonLikeObject> getEntriesAsTuples() {

--- a/jpyinterpreter/src/main/java/ai/timefold/jpyinterpreter/types/collections/view/DictKeyView.java
+++ b/jpyinterpreter/src/main/java/ai/timefold/jpyinterpreter/types/collections/view/DictKeyView.java
@@ -71,7 +71,7 @@ public class DictKeyView extends AbstractPythonLikeObject {
         super(BuiltinTypes.DICT_KEY_VIEW_TYPE);
         this.mapping = mapping;
         this.keySet = mapping.delegate.keySet();
-        __setAttribute("mapping", mapping);
+        $setAttribute("mapping", mapping);
     }
 
     public PythonInteger getKeysSize() {

--- a/jpyinterpreter/src/main/java/ai/timefold/jpyinterpreter/types/collections/view/DictValueView.java
+++ b/jpyinterpreter/src/main/java/ai/timefold/jpyinterpreter/types/collections/view/DictValueView.java
@@ -51,7 +51,7 @@ public class DictValueView extends AbstractPythonLikeObject {
         super(BuiltinTypes.DICT_VALUE_VIEW_TYPE);
         this.mapping = mapping;
         this.valueCollection = mapping.delegate.values();
-        __setAttribute("mapping", mapping);
+        $setAttribute("mapping", mapping);
     }
 
     public PythonInteger getValuesSize() {

--- a/jpyinterpreter/src/main/java/ai/timefold/jpyinterpreter/types/datetime/PythonDate.java
+++ b/jpyinterpreter/src/main/java/ai/timefold/jpyinterpreter/types/datetime/PythonDate.java
@@ -49,9 +49,9 @@ public class PythonDate<T extends PythonDate<?>> extends AbstractPythonLikeObjec
             PythonLikeComparable.setup(DATE_TYPE);
             registerMethods();
 
-            DATE_TYPE.__setAttribute("min", new PythonDate(LocalDate.of(1, 1, 1)));
-            DATE_TYPE.__setAttribute("max", new PythonDate(LocalDate.of(9999, 12, 31)));
-            DATE_TYPE.__setAttribute("resolution", new PythonTimeDelta(Duration.ofDays(1)));
+            DATE_TYPE.$setAttribute("min", new PythonDate(LocalDate.of(1, 1, 1)));
+            DATE_TYPE.$setAttribute("max", new PythonDate(LocalDate.of(9999, 12, 31)));
+            DATE_TYPE.$setAttribute("resolution", new PythonTimeDelta(Duration.ofDays(1)));
 
             PythonOverloadImplementor.createDispatchesFor(DATE_TYPE);
         } catch (NoSuchMethodException e) {
@@ -183,7 +183,7 @@ public class PythonDate<T extends PythonDate<?>> extends AbstractPythonLikeObjec
     }
 
     @Override
-    public PythonLikeObject __getAttributeOrNull(String name) {
+    public PythonLikeObject $getAttributeOrNull(String name) {
         switch (name) {
             case "year":
                 return year;
@@ -192,7 +192,7 @@ public class PythonDate<T extends PythonDate<?>> extends AbstractPythonLikeObjec
             case "day":
                 return day;
             default:
-                return super.__getAttributeOrNull(name);
+                return super.$getAttributeOrNull(name);
         }
     }
 

--- a/jpyinterpreter/src/main/java/ai/timefold/jpyinterpreter/types/datetime/PythonDateTime.java
+++ b/jpyinterpreter/src/main/java/ai/timefold/jpyinterpreter/types/datetime/PythonDateTime.java
@@ -62,11 +62,11 @@ public class PythonDateTime extends PythonDate<PythonDateTime> {
             PythonLikeComparable.setup(DATE_TIME_TYPE);
             registerMethods();
 
-            DATE_TIME_TYPE.__setAttribute("min", new PythonDateTime(LocalDate.of(1, 1, 1),
+            DATE_TIME_TYPE.$setAttribute("min", new PythonDateTime(LocalDate.of(1, 1, 1),
                     LocalTime.MAX));
-            DATE_TIME_TYPE.__setAttribute("max", new PythonDateTime(LocalDate.of(9999, 12, 31),
+            DATE_TIME_TYPE.$setAttribute("max", new PythonDateTime(LocalDate.of(9999, 12, 31),
                     LocalTime.MIN));
-            DATE_TIME_TYPE.__setAttribute("resolution", new PythonTimeDelta(Duration.ofNanos(1000L)));
+            DATE_TIME_TYPE.$setAttribute("resolution", new PythonTimeDelta(Duration.ofNanos(1000L)));
 
             PythonOverloadImplementor.createDispatchesFor(DATE_TIME_TYPE);
         } catch (NoSuchMethodException e) {
@@ -300,7 +300,7 @@ public class PythonDateTime extends PythonDate<PythonDateTime> {
     }
 
     @Override
-    public PythonLikeObject __getAttributeOrNull(String name) {
+    public PythonLikeObject $getAttributeOrNull(String name) {
         switch (name) {
             case "hour":
                 return hour;
@@ -315,7 +315,7 @@ public class PythonDateTime extends PythonDate<PythonDateTime> {
             case "tzinfo":
                 return tzinfo;
             default:
-                return super.__getAttributeOrNull(name);
+                return super.$getAttributeOrNull(name);
         }
     }
 

--- a/jpyinterpreter/src/main/java/ai/timefold/jpyinterpreter/types/datetime/PythonTime.java
+++ b/jpyinterpreter/src/main/java/ai/timefold/jpyinterpreter/types/datetime/PythonTime.java
@@ -43,9 +43,9 @@ public class PythonTime extends AbstractPythonLikeObject {
         try {
             registerMethods();
 
-            TIME_TYPE.__setAttribute("min", new PythonTime(LocalTime.MAX));
-            TIME_TYPE.__setAttribute("max", new PythonTime(LocalTime.MIN));
-            TIME_TYPE.__setAttribute("resolution", new PythonTimeDelta(Duration.ofNanos(1000L)));
+            TIME_TYPE.$setAttribute("min", new PythonTime(LocalTime.MAX));
+            TIME_TYPE.$setAttribute("max", new PythonTime(LocalTime.MIN));
+            TIME_TYPE.$setAttribute("resolution", new PythonTimeDelta(Duration.ofNanos(1000L)));
 
             PythonOverloadImplementor.createDispatchesFor(TIME_TYPE);
         } catch (NoSuchMethodException e) {
@@ -133,7 +133,7 @@ public class PythonTime extends AbstractPythonLikeObject {
     }
 
     @Override
-    public PythonLikeObject __getAttributeOrNull(String name) {
+    public PythonLikeObject $getAttributeOrNull(String name) {
         switch (name) {
             case "hour":
                 return hour;
@@ -148,7 +148,7 @@ public class PythonTime extends AbstractPythonLikeObject {
             case "fold":
                 return fold;
             default:
-                return super.__getAttributeOrNull(name);
+                return super.$getAttributeOrNull(name);
         }
     }
 

--- a/jpyinterpreter/src/main/java/ai/timefold/jpyinterpreter/types/datetime/PythonTimeDelta.java
+++ b/jpyinterpreter/src/main/java/ai/timefold/jpyinterpreter/types/datetime/PythonTimeDelta.java
@@ -38,10 +38,10 @@ public class PythonTimeDelta extends AbstractPythonLikeObject implements PythonL
             PythonLikeComparable.setup(TIME_DELTA_TYPE);
             registerMethods();
 
-            TIME_DELTA_TYPE.__setAttribute("min", new PythonTimeDelta(Duration.ofDays(-999999999)));
-            TIME_DELTA_TYPE.__setAttribute("max", new PythonTimeDelta(Duration.ofDays(1000000000)
+            TIME_DELTA_TYPE.$setAttribute("min", new PythonTimeDelta(Duration.ofDays(-999999999)));
+            TIME_DELTA_TYPE.$setAttribute("max", new PythonTimeDelta(Duration.ofDays(1000000000)
                     .minusNanos(1000)));
-            TIME_DELTA_TYPE.__setAttribute("resolution", new PythonTimeDelta(Duration.ofNanos(1000)));
+            TIME_DELTA_TYPE.$setAttribute("resolution", new PythonTimeDelta(Duration.ofNanos(1000)));
 
             PythonOverloadImplementor.createDispatchesFor(TIME_DELTA_TYPE);
         } catch (NoSuchMethodException e) {
@@ -133,7 +133,7 @@ public class PythonTimeDelta extends AbstractPythonLikeObject implements PythonL
     }
 
     @Override
-    public PythonLikeObject __getAttributeOrNull(String name) {
+    public PythonLikeObject $getAttributeOrNull(String name) {
         switch (name) {
             case "days":
                 return days;
@@ -142,7 +142,7 @@ public class PythonTimeDelta extends AbstractPythonLikeObject implements PythonL
             case "microseconds":
                 return microseconds;
             default:
-                return super.__getAttributeOrNull(name);
+                return super.$getAttributeOrNull(name);
         }
     }
 

--- a/jpyinterpreter/src/main/java/ai/timefold/jpyinterpreter/types/errors/PythonBaseException.java
+++ b/jpyinterpreter/src/main/java/ai/timefold/jpyinterpreter/types/errors/PythonBaseException.java
@@ -50,8 +50,8 @@ public class PythonBaseException extends RuntimeException implements PythonLikeO
         this.type = type;
         this.args = args;
         this.dict = new HashMap<>();
-        __setAttribute("args", PythonLikeTuple.fromList(args));
-        __setAttribute("__cause__", PythonNone.INSTANCE);
+        $setAttribute("args", PythonLikeTuple.fromList(args));
+        $setAttribute("__cause__", PythonNone.INSTANCE);
     }
 
     public PythonBaseException(PythonLikeType type, String message) {
@@ -59,8 +59,8 @@ public class PythonBaseException extends RuntimeException implements PythonLikeO
         this.type = type;
         this.args = List.of(PythonString.valueOf(message));
         this.dict = new HashMap<>();
-        __setAttribute("args", PythonLikeTuple.fromList(args));
-        __setAttribute("__cause__", PythonNone.INSTANCE);
+        $setAttribute("args", PythonLikeTuple.fromList(args));
+        $setAttribute("__cause__", PythonNone.INSTANCE);
     }
 
     /**
@@ -81,34 +81,34 @@ public class PythonBaseException extends RuntimeException implements PythonLikeO
     public Throwable initCause(Throwable cause) {
         super.initCause(cause);
         if (cause instanceof PythonLikeObject pythonError) {
-            __setAttribute("__cause__", pythonError);
+            $setAttribute("__cause__", pythonError);
         } else {
-            __setAttribute("__cause__", new JavaObjectWrapper(cause));
+            $setAttribute("__cause__", new JavaObjectWrapper(cause));
         }
         return this;
     }
 
     @Override
-    public PythonLikeObject __getAttributeOrNull(String attributeName) {
+    public PythonLikeObject $getAttributeOrNull(String attributeName) {
         return dict.get(attributeName);
     }
 
     @Override
-    public void __setAttribute(String attributeName, PythonLikeObject value) {
+    public void $setAttribute(String attributeName, PythonLikeObject value) {
         dict.put(attributeName, value);
     }
 
     @Override
-    public void __deleteAttribute(String attributeName) {
+    public void $deleteAttribute(String attributeName) {
         dict.remove(attributeName);
     }
 
     public PythonLikeTuple $getArgs() {
-        return (PythonLikeTuple) __getAttributeOrError("args");
+        return (PythonLikeTuple) $getAttributeOrError("args");
     }
 
     @Override
-    public PythonLikeType __getType() {
+    public PythonLikeType $getType() {
         return type;
     }
 }

--- a/jpyinterpreter/src/main/java/ai/timefold/jpyinterpreter/types/numeric/PythonBoolean.java
+++ b/jpyinterpreter/src/main/java/ai/timefold/jpyinterpreter/types/numeric/PythonBoolean.java
@@ -95,13 +95,13 @@ public class PythonBoolean extends PythonInteger {
         } else if (tested instanceof Map) {
             return ((Map<?, ?>) tested).size() == 0;
         } else {
-            PythonLikeType testedType = tested.__getType();
-            PythonLikeFunction boolMethod = (PythonLikeFunction) testedType.__getAttributeOrNull("__bool__");
+            PythonLikeType testedType = tested.$getType();
+            PythonLikeFunction boolMethod = (PythonLikeFunction) testedType.$getAttributeOrNull("__bool__");
             if (boolMethod != null) {
                 return isTruthful(boolMethod.$call(List.of(tested), Map.of(), null));
             }
 
-            PythonLikeFunction lenMethod = (PythonLikeFunction) testedType.__getAttributeOrNull("__len__");
+            PythonLikeFunction lenMethod = (PythonLikeFunction) testedType.$getAttributeOrNull("__len__");
             if (lenMethod != null) {
                 return isTruthful(lenMethod.$call(List.of(tested), Map.of(), null));
             }
@@ -119,7 +119,7 @@ public class PythonBoolean extends PythonInteger {
     }
 
     @Override
-    public PythonLikeType __getType() {
+    public PythonLikeType $getType() {
         return BuiltinTypes.BOOLEAN_TYPE;
     }
 

--- a/jpyinterpreter/src/main/java/ai/timefold/jpyinterpreter/types/numeric/PythonFloat.java
+++ b/jpyinterpreter/src/main/java/ai/timefold/jpyinterpreter/types/numeric/PythonFloat.java
@@ -54,8 +54,8 @@ public class PythonFloat extends AbstractPythonLikeObject implements PythonNumbe
                 } else if (value instanceof PythonFloat) {
                     return value;
                 } else {
-                    PythonLikeType valueType = value.__getType();
-                    PythonLikeFunction asFloatFunction = (PythonLikeFunction) (valueType.__getAttributeOrError("__float__"));
+                    PythonLikeType valueType = value.$getType();
+                    PythonLikeFunction asFloatFunction = (PythonLikeFunction) (valueType.$getAttributeOrError("__float__"));
                     return asFloatFunction.$call(List.of(value), Map.of(), null);
                 }
             } else {

--- a/jpyinterpreter/src/main/java/ai/timefold/jpyinterpreter/types/numeric/PythonInteger.java
+++ b/jpyinterpreter/src/main/java/ai/timefold/jpyinterpreter/types/numeric/PythonInteger.java
@@ -51,8 +51,8 @@ public class PythonInteger extends AbstractPythonLikeObject implements PythonNum
                 } else if (value instanceof PythonFloat) {
                     return ((PythonFloat) value).asInteger();
                 } else {
-                    PythonLikeType valueType = value.__getType();
-                    PythonLikeFunction asIntFunction = (PythonLikeFunction) (valueType.__getAttributeOrError("__int__"));
+                    PythonLikeType valueType = value.$getType();
+                    PythonLikeFunction asIntFunction = (PythonLikeFunction) (valueType.$getAttributeOrError("__int__"));
                     return asIntFunction.$call(List.of(value), Map.of(), null);
                 }
             } else {

--- a/jpyinterpreter/src/main/java/ai/timefold/jpyinterpreter/types/wrappers/CPythonType.java
+++ b/jpyinterpreter/src/main/java/ai/timefold/jpyinterpreter/types/wrappers/CPythonType.java
@@ -44,7 +44,7 @@ public class CPythonType extends PythonLikeType {
     }
 
     @Override
-    public PythonLikeObject __getAttributeOrNull(String attributeName) {
+    public PythonLikeObject $getAttributeOrNull(String attributeName) {
         switch (attributeName) {
             case "__eq__":
                 return cachedAttributeMap.computeIfAbsent(attributeName,
@@ -114,19 +114,19 @@ public class CPythonType extends PythonLikeType {
     }
 
     @Override
-    public void __setAttribute(String attributeName, PythonLikeObject value) {
+    public void $setAttribute(String attributeName, PythonLikeObject value) {
         cachedAttributeMap.put(attributeName, value);
         CPythonBackedPythonInterpreter.setAttributeOnPythonReference(pythonReference, attributeName, value);
     }
 
     @Override
-    public void __deleteAttribute(String attributeName) {
+    public void $deleteAttribute(String attributeName) {
         cachedAttributeMap.remove(attributeName);
         CPythonBackedPythonInterpreter.deleteAttributeOnPythonReference(pythonReference, attributeName);
     }
 
     @Override
-    public PythonLikeType __getType() {
+    public PythonLikeType $getType() {
         return BuiltinTypes.TYPE_TYPE;
     }
 

--- a/jpyinterpreter/src/main/java/ai/timefold/jpyinterpreter/types/wrappers/JavaObjectWrapper.java
+++ b/jpyinterpreter/src/main/java/ai/timefold/jpyinterpreter/types/wrappers/JavaObjectWrapper.java
@@ -83,7 +83,7 @@ public class JavaObjectWrapper implements PythonLikeObject,
             getterName = (field.getType().equals(boolean.class) ? "is" : "get")
                     + capitalizedName;
         }
-        PythonLikeObject object = type.__getAttributeOrNull(getterName);
+        PythonLikeObject object = type.$getAttributeOrNull(getterName);
         if (object instanceof JavaMethodReference methodReference) {
             return methodReference.getMethod();
         }
@@ -97,7 +97,7 @@ public class JavaObjectWrapper implements PythonLikeObject,
                 propertyName.isEmpty() ? "" : propertyName.substring(0, 1).toUpperCase() + propertyName.substring(1);
         String setterName = "set" + capitalizedName;
 
-        PythonLikeObject object = type.__getAttributeOrNull(setterName);
+        PythonLikeObject object = type.$getAttributeOrNull(setterName);
         if (object instanceof JavaMethodReference methodReference) {
             return methodReference.getMethod();
         }
@@ -234,7 +234,7 @@ public class JavaObjectWrapper implements PythonLikeObject,
     }
 
     @Override
-    public PythonLikeObject __getAttributeOrNull(String attributeName) {
+    public PythonLikeObject $getAttributeOrNull(String attributeName) {
         Field field = attributeNameToMemberListMap.get(attributeName);
         if (field == null) {
             return null;
@@ -255,7 +255,7 @@ public class JavaObjectWrapper implements PythonLikeObject,
     }
 
     @Override
-    public void __setAttribute(String attributeName, PythonLikeObject value) {
+    public void $setAttribute(String attributeName, PythonLikeObject value) {
         Field field = attributeNameToMemberListMap.get(attributeName);
         if (field == null) {
             throw new AttributeError("(%s) object does not have attribute (%s)."
@@ -275,12 +275,12 @@ public class JavaObjectWrapper implements PythonLikeObject,
     }
 
     @Override
-    public void __deleteAttribute(String attributeName) {
+    public void $deleteAttribute(String attributeName) {
         throw new IllegalArgumentException("Cannot delete attributes on type '" + objectClass + "'");
     }
 
     @Override
-    public PythonLikeType __getType() {
+    public PythonLikeType $getType() {
         return type;
     }
 

--- a/jpyinterpreter/src/main/java/ai/timefold/jpyinterpreter/types/wrappers/PythonLikeFunctionWrapper.java
+++ b/jpyinterpreter/src/main/java/ai/timefold/jpyinterpreter/types/wrappers/PythonLikeFunctionWrapper.java
@@ -33,24 +33,24 @@ public final class PythonLikeFunctionWrapper implements PythonLikeFunction {
         return wrapped.$call(positionalArguments, namedArguments, callerInstance);
     }
 
-    public PythonLikeObject __getAttributeOrNull(String attributeName) {
-        return wrapped.__getAttributeOrNull(attributeName);
+    public PythonLikeObject $getAttributeOrNull(String attributeName) {
+        return wrapped.$getAttributeOrNull(attributeName);
     }
 
-    public PythonLikeObject __getAttributeOrError(String attributeName) {
-        return wrapped.__getAttributeOrError(attributeName);
+    public PythonLikeObject $getAttributeOrError(String attributeName) {
+        return wrapped.$getAttributeOrError(attributeName);
     }
 
-    public void __setAttribute(String attributeName, PythonLikeObject value) {
-        wrapped.__setAttribute(attributeName, value);
+    public void $setAttribute(String attributeName, PythonLikeObject value) {
+        wrapped.$setAttribute(attributeName, value);
     }
 
-    public void __deleteAttribute(String attributeName) {
-        wrapped.__deleteAttribute(attributeName);
+    public void $deleteAttribute(String attributeName) {
+        wrapped.$deleteAttribute(attributeName);
     }
 
-    public PythonLikeType __getType() {
-        return wrapped.__getType();
+    public PythonLikeType $getType() {
+        return wrapped.$getType();
     }
 
     public PythonLikeObject $method$__getattribute__(PythonString pythonName) {

--- a/jpyinterpreter/src/main/java/ai/timefold/jpyinterpreter/types/wrappers/PythonObjectWrapper.java
+++ b/jpyinterpreter/src/main/java/ai/timefold/jpyinterpreter/types/wrappers/PythonObjectWrapper.java
@@ -33,20 +33,20 @@ public class PythonObjectWrapper extends CPythonBackedPythonLikeObject
     }
 
     @Override
-    public PythonLikeObject __getAttributeOrNull(String attributeName) {
+    public PythonLikeObject $getAttributeOrNull(String attributeName) {
         return cachedAttributeMap.computeIfAbsent(attributeName,
                 key -> CPythonBackedPythonInterpreter.lookupAttributeOnPythonReference($cpythonReference,
                         attributeName, $instanceMap));
     }
 
     @Override
-    public void __setAttribute(String attributeName, PythonLikeObject value) {
+    public void $setAttribute(String attributeName, PythonLikeObject value) {
         cachedAttributeMap.put(attributeName, value);
         CPythonBackedPythonInterpreter.setAttributeOnPythonReference($cpythonReference, attributeName, value);
     }
 
     @Override
-    public void __deleteAttribute(String attributeName) {
+    public void $deleteAttribute(String attributeName) {
         cachedAttributeMap.remove(attributeName);
         CPythonBackedPythonInterpreter.deleteAttributeOnPythonReference($cpythonReference, attributeName);
     }
@@ -63,7 +63,7 @@ public class PythonObjectWrapper extends CPythonBackedPythonLikeObject
             return 0;
         }
 
-        PythonLikeFunction lessThan = (PythonLikeFunction) __getType().__getAttributeOrError("__lt__");
+        PythonLikeFunction lessThan = (PythonLikeFunction) $getType().$getAttributeOrError("__lt__");
         PythonLikeObject result = lessThan.$call(List.of(this, other), Map.of(), null);
 
         if (result instanceof PythonBoolean) {
@@ -73,8 +73,8 @@ public class PythonObjectWrapper extends CPythonBackedPythonLikeObject
                 return 1;
             }
         } else {
-            throw new NotImplementedError("Cannot compare " + this.__getType().getTypeName() +
-                    " with " + other.__getType().getTypeName());
+            throw new NotImplementedError("Cannot compare " + this.$getType().getTypeName() +
+                    " with " + other.$getType().getTypeName());
         }
     }
 
@@ -87,7 +87,7 @@ public class PythonObjectWrapper extends CPythonBackedPythonLikeObject
             return false;
         }
         PythonObjectWrapper other = (PythonObjectWrapper) o;
-        Object maybeEquals = __getType().__getAttributeOrNull("__eq__");
+        Object maybeEquals = $getType().$getAttributeOrNull("__eq__");
         if (!(maybeEquals instanceof PythonLikeFunction)) {
             return super.equals(o);
         }
@@ -101,7 +101,7 @@ public class PythonObjectWrapper extends CPythonBackedPythonLikeObject
 
     @Override
     public int hashCode() {
-        Object maybeHash = __getType().__getAttributeOrNull("__hash__");
+        Object maybeHash = $getType().$getAttributeOrNull("__hash__");
         if (!(maybeHash instanceof PythonLikeFunction)) {
             return super.hashCode();
         }
@@ -121,7 +121,7 @@ public class PythonObjectWrapper extends CPythonBackedPythonLikeObject
 
     @Override
     public String toString() {
-        Object maybeStr = __getType().__getAttributeOrNull("__str__");
+        Object maybeStr = $getType().$getAttributeOrNull("__str__");
         if (!(maybeStr instanceof PythonLikeFunction)) {
             return super.toString();
         }

--- a/jpyinterpreter/src/main/java/ai/timefold/jpyinterpreter/util/StringFormatter.java
+++ b/jpyinterpreter/src/main/java/ai/timefold/jpyinterpreter/util/StringFormatter.java
@@ -273,7 +273,7 @@ public class StringFormatter {
                     toConvert = ((PythonFloat) toConvert).asInteger();
                 }
                 if (!(toConvert instanceof PythonInteger)) {
-                    throw new TypeError("%d format: a real number is required, not " + toConvert.__getType().getTypeName());
+                    throw new TypeError("%d format: a real number is required, not " + toConvert.$getType().getTypeName());
                 }
                 result = ((PythonInteger) toConvert).value.toString(10);
                 break;
@@ -283,7 +283,7 @@ public class StringFormatter {
                     toConvert = ((PythonFloat) toConvert).asInteger();
                 }
                 if (!(toConvert instanceof PythonInteger)) {
-                    throw new TypeError("%o format: a real number is required, not " + toConvert.__getType().getTypeName());
+                    throw new TypeError("%o format: a real number is required, not " + toConvert.$getType().getTypeName());
                 }
                 result = ((PythonInteger) toConvert).value.toString(8);
                 if (useAlternateForm) {
@@ -296,7 +296,7 @@ public class StringFormatter {
                     toConvert = ((PythonFloat) toConvert).asInteger();
                 }
                 if (!(toConvert instanceof PythonInteger)) {
-                    throw new TypeError("%x format: a real number is required, not " + toConvert.__getType().getTypeName());
+                    throw new TypeError("%x format: a real number is required, not " + toConvert.$getType().getTypeName());
                 }
                 result = ((PythonInteger) toConvert).value.toString(16);
                 if (useAlternateForm) {
@@ -309,7 +309,7 @@ public class StringFormatter {
                     toConvert = ((PythonFloat) toConvert).asInteger();
                 }
                 if (!(toConvert instanceof PythonInteger)) {
-                    throw new TypeError("%X format: a real number is required, not " + toConvert.__getType().getTypeName());
+                    throw new TypeError("%X format: a real number is required, not " + toConvert.$getType().getTypeName());
                 }
                 result = ((PythonInteger) toConvert).value.toString(16).toUpperCase();
                 if (useAlternateForm) {
@@ -322,7 +322,7 @@ public class StringFormatter {
                     toConvert = ((PythonInteger) toConvert).asFloat();
                 }
                 if (!(toConvert instanceof PythonFloat)) {
-                    throw new TypeError("%e format: a real number is required, not " + toConvert.__getType().getTypeName());
+                    throw new TypeError("%e format: a real number is required, not " + toConvert.$getType().getTypeName());
                 }
                 BigDecimal value = BigDecimal.valueOf(((PythonFloat) toConvert).value);
                 result = getUppercaseEngineeringString(value, maybePrecision.map(precision -> precision + 1)
@@ -337,7 +337,7 @@ public class StringFormatter {
                     toConvert = ((PythonInteger) toConvert).asFloat();
                 }
                 if (!(toConvert instanceof PythonFloat)) {
-                    throw new TypeError("%E format: a real number is required, not " + toConvert.__getType().getTypeName());
+                    throw new TypeError("%E format: a real number is required, not " + toConvert.$getType().getTypeName());
                 }
                 BigDecimal value = BigDecimal.valueOf(((PythonFloat) toConvert).value);
                 result = getUppercaseEngineeringString(value, maybePrecision.map(precision -> precision + 1)
@@ -352,7 +352,7 @@ public class StringFormatter {
                     toConvert = ((PythonInteger) toConvert).asFloat();
                 }
                 if (!(toConvert instanceof PythonFloat)) {
-                    throw new TypeError("%f format: a real number is required, not " + toConvert.__getType().getTypeName());
+                    throw new TypeError("%f format: a real number is required, not " + toConvert.$getType().getTypeName());
                 }
                 BigDecimal value = BigDecimal.valueOf(((PythonFloat) toConvert).value);
                 BigDecimal valueWithPrecision = value.setScale(maybePrecision.orElse(6), RoundingMode.HALF_EVEN);
@@ -367,7 +367,7 @@ public class StringFormatter {
                     toConvert = ((PythonInteger) toConvert).asFloat();
                 }
                 if (!(toConvert instanceof PythonFloat)) {
-                    throw new TypeError("%g format: a real number is required, not " + toConvert.__getType().getTypeName());
+                    throw new TypeError("%g format: a real number is required, not " + toConvert.$getType().getTypeName());
                 }
                 BigDecimal value = BigDecimal.valueOf(((PythonFloat) toConvert).value);
                 BigDecimal valueWithPrecision;
@@ -390,7 +390,7 @@ public class StringFormatter {
                     toConvert = ((PythonInteger) toConvert).asFloat();
                 }
                 if (!(toConvert instanceof PythonFloat)) {
-                    throw new TypeError("%G format: a real number is required, not " + toConvert.__getType().getTypeName());
+                    throw new TypeError("%G format: a real number is required, not " + toConvert.$getType().getTypeName());
                 }
                 BigDecimal value = BigDecimal.valueOf(((PythonFloat) toConvert).value);
                 BigDecimal valueWithPrecision;

--- a/jpyinterpreter/src/test/java/ai/timefold/jpyinterpreter/PythonOverloadImplementorTest.java
+++ b/jpyinterpreter/src/test/java/ai/timefold/jpyinterpreter/PythonOverloadImplementorTest.java
@@ -24,7 +24,7 @@ public class PythonOverloadImplementorTest {
         PythonOverloadImplementor.createDispatchesFor(SingleOverload.TYPE);
 
         SingleOverload instance = new SingleOverload();
-        PythonLikeFunction overload = (PythonLikeFunction) SingleOverload.TYPE.__getAttributeOrError("overload");
+        PythonLikeFunction overload = (PythonLikeFunction) SingleOverload.TYPE.$getAttributeOrError("overload");
         assertThat(overload.$call(List.of(instance), Map.of(), null)).isEqualTo(PythonString.valueOf("1"));
     }
 
@@ -38,7 +38,7 @@ public class PythonOverloadImplementorTest {
         PythonOverloadImplementor.createDispatchesFor(DifferentArgCountOverloads.TYPE);
 
         DifferentArgCountOverloads instance = new DifferentArgCountOverloads();
-        PythonLikeFunction overload = (PythonLikeFunction) DifferentArgCountOverloads.TYPE.__getAttributeOrError("overload");
+        PythonLikeFunction overload = (PythonLikeFunction) DifferentArgCountOverloads.TYPE.$getAttributeOrError("overload");
         assertThat(overload.$call(List.of(instance), Map.of(), null)).isEqualTo(PythonString.valueOf("1"));
         assertThat(overload.$call(List.of(instance, PythonInteger.valueOf(2)), Map.of(), null))
                 .isEqualTo(PythonInteger.valueOf(2));
@@ -60,7 +60,7 @@ public class PythonOverloadImplementorTest {
         PythonOverloadImplementor.createDispatchesFor(DifferentArgTypeOverloads.TYPE);
 
         DifferentArgTypeOverloads instance = new DifferentArgTypeOverloads();
-        PythonLikeFunction overload = (PythonLikeFunction) DifferentArgTypeOverloads.TYPE.__getAttributeOrError("overload");
+        PythonLikeFunction overload = (PythonLikeFunction) DifferentArgTypeOverloads.TYPE.$getAttributeOrError("overload");
         assertThat(overload.$call(List.of(instance, PythonString.valueOf("1")), Map.of(), null))
                 .isEqualTo(PythonString.valueOf("1"));
 
@@ -94,7 +94,7 @@ public class PythonOverloadImplementorTest {
         PythonOverloadImplementor.createDispatchesFor(VariousOverloads.TYPE);
 
         VariousOverloads instance = new VariousOverloads();
-        PythonLikeFunction overload = (PythonLikeFunction) VariousOverloads.TYPE.__getAttributeOrError("overload");
+        PythonLikeFunction overload = (PythonLikeFunction) VariousOverloads.TYPE.$getAttributeOrError("overload");
         assertThat(overload.$call(List.of(instance), Map.of(), null)).isEqualTo(PythonString.valueOf("1"));
         assertThat(overload.$call(List.of(instance, PythonString.valueOf("a")), Map.of(), null))
                 .isEqualTo(PythonString.valueOf("a 1"));

--- a/jpyinterpreter/src/test/java/ai/timefold/jpyinterpreter/types/wrappers/JavaObjectWrapperTest.java
+++ b/jpyinterpreter/src/test/java/ai/timefold/jpyinterpreter/types/wrappers/JavaObjectWrapperTest.java
@@ -58,7 +58,7 @@ public class JavaObjectWrapperTest {
     void testCallingRecordGetter() {
         TestObject object = new TestObject("My name");
         JavaObjectWrapper wrapper = new JavaObjectWrapper(object);
-        PythonLikeObject result = wrapper.__getAttributeOrNull("name");
+        PythonLikeObject result = wrapper.$getAttributeOrNull("name");
         assertThat(result).isEqualTo(PythonString.valueOf("My name"));
     }
 

--- a/timefold-solver-python-core/src/main/java/ai/timefold/solver/python/TimefoldObjectReference.java
+++ b/timefold-solver-python-core/src/main/java/ai/timefold/solver/python/TimefoldObjectReference.java
@@ -17,22 +17,22 @@ public class TimefoldObjectReference implements PythonLikeObject {
     }
 
     @Override
-    public PythonLikeObject __getAttributeOrNull(String attributeName) {
+    public PythonLikeObject $getAttributeOrNull(String attributeName) {
         return null;
     }
 
     @Override
-    public void __setAttribute(String attributeName, PythonLikeObject value) {
+    public void $setAttribute(String attributeName, PythonLikeObject value) {
 
     }
 
     @Override
-    public void __deleteAttribute(String attributeName) {
+    public void $deleteAttribute(String attributeName) {
 
     }
 
     @Override
-    public PythonLikeType __getType() {
+    public PythonLikeType $getType() {
         return null;
     }
 


### PR DESCRIPTION
- This prevents naming conflicts in Python since '$' is invalid in Python identifier
- Additionally, it make it consistent with the names of other generated methods/fields in the interpreter
