### PR TITLE
fix: Generate getters/setters that replace null with None (or vice versa)

### DIFF
--- a/jpyinterpreter/src/main/java/ai/timefold/jpyinterpreter/types/PythonLikeType.java
+++ b/jpyinterpreter/src/main/java/ai/timefold/jpyinterpreter/types/PythonLikeType.java
@@ -107,7 +107,9 @@ public class PythonLikeType implements PythonLikeObject,
     }
 
     public static PythonLikeType getTypeForNewClass(String typeName, String internalName) {
-        return new PythonLikeType(typeName, internalName);
+        var out = new PythonLikeType(typeName, internalName);
+        out.__dir__.put("__class__", out);
+        return out;
     }
 
     public void initializeNewType(List<PythonLikeType> superClassTypes) {

--- a/jpyinterpreter/tests/test_classes.py
+++ b/jpyinterpreter/tests/test_classes.py
@@ -902,7 +902,7 @@ def test_class_annotations():
     assert annotations[0].forRemoval()
     assert annotations[0].since() == '0.0.0'
 
-    annotations = translated_class.getField('my_field').getAnnotations()
+    annotations = translated_class.getMethod('getMy_field').getAnnotations()
     assert len(annotations) == 2
     assert isinstance(annotations[0], Deprecated)
     assert annotations[0].forRemoval()


### PR DESCRIPTION
- Timefold considers None to be initialized, although it represents an uninitialized value

- Instead of annotating the fields directly, we could annotate getters/setters instead

- If None is assignable to the field type, the getter is `return this.field != None? this.field : null`; otherwise it's `return this.field`

- If None is assignable to the field type, the setter is `this.field =(value != null)? value : None`; otherwise it's `this.field = value`

- Assign the `__class__` field of a new class to itself to match CPython.