### PR TITLE
feat: Add support for nearby selection

### DIFF
--- a/jpyinterpreter/src/main/java/ai/timefold/jpyinterpreter/PythonClassTranslator.java
+++ b/jpyinterpreter/src/main/java/ai/timefold/jpyinterpreter/PythonClassTranslator.java
@@ -23,6 +23,7 @@ import ai.timefold.jpyinterpreter.implementors.JavaComparableImplementor;
 import ai.timefold.jpyinterpreter.implementors.JavaEqualsImplementor;
 import ai.timefold.jpyinterpreter.implementors.JavaHashCodeImplementor;
 import ai.timefold.jpyinterpreter.implementors.JavaInterfaceImplementor;
+import ai.timefold.jpyinterpreter.implementors.JavaPythonTypeConversionImplementor;
 import ai.timefold.jpyinterpreter.implementors.PythonConstantsImplementor;
 import ai.timefold.jpyinterpreter.opcodes.AbstractOpcode;
 import ai.timefold.jpyinterpreter.opcodes.Opcode;
@@ -1096,6 +1097,13 @@ public class PythonClassTranslator {
                 getUnwrappedJavaObject(methodVisitor, type);
                 typeDescriptor = Type.getDescriptor(type.getJavaObjectWrapperType());
             } else {
+                methodVisitor.visitLdcInsn(Type.getType(type.getJavaTypeDescriptor()));
+                methodVisitor.visitMethodInsn(Opcodes.INVOKESTATIC,
+                        Type.getInternalName(JavaPythonTypeConversionImplementor.class),
+                        "coerceToType", Type.getMethodDescriptor(Type.getType(Object.class),
+                                Type.getType(PythonLikeObject.class),
+                                Type.getType(Class.class)),
+                        false);
                 methodVisitor.visitTypeInsn(Opcodes.CHECKCAST, type.getJavaTypeInternalName());
             }
             methodVisitor.visitFieldInsn(Opcodes.PUTFIELD, classInternalName, getJavaFieldName(field),
@@ -1231,6 +1239,12 @@ public class PythonClassTranslator {
             }
 
             var attributeType = attributeNameToType.get(field);
+            methodVisitor.visitLdcInsn(Type.getType(attributeType.getJavaTypeDescriptor()));
+            methodVisitor.visitMethodInsn(Opcodes.INVOKESTATIC, Type.getInternalName(JavaPythonTypeConversionImplementor.class),
+                    "coerceToType", Type.getMethodDescriptor(Type.getType(Object.class),
+                            Type.getType(PythonLikeObject.class),
+                            Type.getType(Class.class)),
+                    false);
             methodVisitor.visitTypeInsn(Opcodes.CHECKCAST, attributeNameToType.get(field).getJavaTypeInternalName());
 
             if (attributeType.getJavaTypeInternalName().equals(Type.getInternalName(JavaObjectWrapper.class))) {

--- a/jpyinterpreter/src/main/java/ai/timefold/jpyinterpreter/implementors/KnownCallImplementor.java
+++ b/jpyinterpreter/src/main/java/ai/timefold/jpyinterpreter/implementors/KnownCallImplementor.java
@@ -113,6 +113,12 @@ public class KnownCallImplementor {
         // Now load and typecheck the local variables
         for (int i = 0; i < Math.min(specPositionalArgumentCount, argumentCount); i++) {
             localVariableHelper.readTemp(methodVisitor, Type.getType(PythonLikeObject.class), argumentLocals[i]);
+            methodVisitor.visitLdcInsn(Type.getType(pythonFunctionSignature.getArgumentSpec().getArgumentType(i)));
+            methodVisitor.visitMethodInsn(Opcodes.INVOKESTATIC, Type.getInternalName(JavaPythonTypeConversionImplementor.class),
+                    "coerceToType", Type.getMethodDescriptor(Type.getType(Object.class),
+                            Type.getType(PythonLikeObject.class),
+                            Type.getType(Class.class)),
+                    false);
             methodVisitor.visitTypeInsn(Opcodes.CHECKCAST,
                     Type.getInternalName(pythonFunctionSignature.getArgumentSpec().getArgumentType(i)));
         }
@@ -279,6 +285,12 @@ public class KnownCallImplementor {
         // Load arguments in proper order and typecast them
         for (int i = 0; i < specTotalArgumentCount; i++) {
             localVariableHelper.readTemp(methodVisitor, Type.getType(PythonLikeObject.class), argumentLocals[i]);
+            methodVisitor.visitLdcInsn(Type.getType(pythonFunctionSignature.getArgumentSpec().getArgumentType(i)));
+            methodVisitor.visitMethodInsn(Opcodes.INVOKESTATIC, Type.getInternalName(JavaPythonTypeConversionImplementor.class),
+                    "coerceToType", Type.getMethodDescriptor(Type.getType(Object.class),
+                            Type.getType(PythonLikeObject.class),
+                            Type.getType(Class.class)),
+                    false);
             methodVisitor.visitTypeInsn(Opcodes.CHECKCAST,
                     Type.getInternalName(pythonFunctionSignature.getArgumentSpec().getArgumentType(i)));
         }
@@ -480,6 +492,12 @@ public class KnownCallImplementor {
             methodVisitor.visitMethodInsn(Opcodes.INVOKEINTERFACE, Type.getInternalName(List.class),
                     "get", Type.getMethodDescriptor(Type.getType(Object.class), Type.INT_TYPE),
                     true);
+            methodVisitor.visitLdcInsn(descriptorParameterTypes[i]);
+            methodVisitor.visitMethodInsn(Opcodes.INVOKESTATIC, Type.getInternalName(JavaPythonTypeConversionImplementor.class),
+                    "coerceToType", Type.getMethodDescriptor(Type.getType(Object.class),
+                            Type.getType(PythonLikeObject.class),
+                            Type.getType(Class.class)),
+                    false);
             methodVisitor.visitTypeInsn(Opcodes.CHECKCAST, descriptorParameterTypes[i].getInternalName());
             methodVisitor.visitInsn(Opcodes.SWAP);
         }

--- a/jpyinterpreter/src/main/java/ai/timefold/jpyinterpreter/implementors/ObjectImplementor.java
+++ b/jpyinterpreter/src/main/java/ai/timefold/jpyinterpreter/implementors/ObjectImplementor.java
@@ -140,6 +140,12 @@ public class ObjectImplementor {
             FieldDescriptor fieldDescriptor = maybeFieldDescriptor.get();
             methodVisitor.visitTypeInsn(Opcodes.CHECKCAST, fieldDescriptor.declaringClassInternalName());
             StackManipulationImplementor.swap(methodVisitor);
+            methodVisitor.visitLdcInsn(Type.getType(fieldDescriptor.fieldPythonLikeType().getJavaTypeDescriptor()));
+            methodVisitor.visitMethodInsn(Opcodes.INVOKESTATIC, Type.getInternalName(JavaPythonTypeConversionImplementor.class),
+                    "coerceToType", Type.getMethodDescriptor(Type.getType(Object.class),
+                            Type.getType(PythonLikeObject.class),
+                            Type.getType(Class.class)),
+                    false);
             methodVisitor.visitTypeInsn(Opcodes.CHECKCAST, fieldDescriptor.fieldPythonLikeType().getJavaTypeInternalName());
             if (fieldDescriptor.isJavaType()) {
                 // Need to unwrap the object

--- a/jpyinterpreter/src/main/java/ai/timefold/jpyinterpreter/types/Coercible.java
+++ b/jpyinterpreter/src/main/java/ai/timefold/jpyinterpreter/types/Coercible.java
@@ -1,0 +1,5 @@
+package ai.timefold.jpyinterpreter.types;
+
+public interface Coercible {
+    <T> T coerce(Class<T> targetType);
+}

--- a/jpyinterpreter/src/main/java/ai/timefold/jpyinterpreter/types/numeric/PythonFloat.java
+++ b/jpyinterpreter/src/main/java/ai/timefold/jpyinterpreter/types/numeric/PythonFloat.java
@@ -15,6 +15,7 @@ import ai.timefold.jpyinterpreter.PythonOverloadImplementor;
 import ai.timefold.jpyinterpreter.PythonUnaryOperator;
 import ai.timefold.jpyinterpreter.types.AbstractPythonLikeObject;
 import ai.timefold.jpyinterpreter.types.BuiltinTypes;
+import ai.timefold.jpyinterpreter.types.Coercible;
 import ai.timefold.jpyinterpreter.types.NotImplemented;
 import ai.timefold.jpyinterpreter.types.PythonLikeComparable;
 import ai.timefold.jpyinterpreter.types.PythonLikeFunction;
@@ -29,7 +30,8 @@ import ai.timefold.jpyinterpreter.util.DefaultFormatSpec;
 import ai.timefold.jpyinterpreter.util.StringFormatter;
 import ai.timefold.solver.core.impl.domain.solution.cloner.PlanningImmutable;
 
-public class PythonFloat extends AbstractPythonLikeObject implements PythonNumber, PlanningImmutable {
+public class PythonFloat extends AbstractPythonLikeObject implements PythonNumber, PlanningImmutable,
+        Coercible {
     public final double value;
 
     static {
@@ -792,5 +794,13 @@ public class PythonFloat extends AbstractPythonLikeObject implements PythonNumbe
         out.append(numberFormat.format(value));
         StringFormatter.align(out, formatSpec, DefaultFormatSpec.AlignmentOption.RIGHT_ALIGN);
         return PythonString.valueOf(out.toString());
+    }
+
+    @Override
+    public <T> T coerce(Class<T> targetType) {
+        if (targetType.equals(PythonInteger.class)) {
+            return (T) PythonInteger.valueOf((long) value);
+        }
+        return null;
     }
 }

--- a/jpyinterpreter/src/main/java/ai/timefold/jpyinterpreter/types/numeric/PythonInteger.java
+++ b/jpyinterpreter/src/main/java/ai/timefold/jpyinterpreter/types/numeric/PythonInteger.java
@@ -13,6 +13,7 @@ import ai.timefold.jpyinterpreter.PythonOverloadImplementor;
 import ai.timefold.jpyinterpreter.PythonUnaryOperator;
 import ai.timefold.jpyinterpreter.types.AbstractPythonLikeObject;
 import ai.timefold.jpyinterpreter.types.BuiltinTypes;
+import ai.timefold.jpyinterpreter.types.Coercible;
 import ai.timefold.jpyinterpreter.types.NotImplemented;
 import ai.timefold.jpyinterpreter.types.PythonLikeFunction;
 import ai.timefold.jpyinterpreter.types.PythonLikeType;
@@ -26,7 +27,8 @@ import ai.timefold.jpyinterpreter.util.DefaultFormatSpec;
 import ai.timefold.jpyinterpreter.util.StringFormatter;
 import ai.timefold.solver.core.impl.domain.solution.cloner.PlanningImmutable;
 
-public class PythonInteger extends AbstractPythonLikeObject implements PythonNumber, PlanningImmutable {
+public class PythonInteger extends AbstractPythonLikeObject implements PythonNumber,
+        PlanningImmutable, Coercible {
     private static final BigInteger MIN_BYTE = BigInteger.valueOf(0);
     private static final BigInteger MAX_BYTE = BigInteger.valueOf(255);
 
@@ -839,5 +841,13 @@ public class PythonInteger extends AbstractPythonLikeObject implements PythonNum
         }
 
         return PythonString.valueOf(out.toString());
+    }
+
+    @Override
+    public <T> T coerce(Class<T> targetType) {
+        if (targetType.equals(PythonFloat.class)) {
+            return (T) PythonFloat.valueOf(value.doubleValue());
+        }
+        return null;
     }
 }

--- a/jpyinterpreter/tests/test_classes.py
+++ b/jpyinterpreter/tests/test_classes.py
@@ -24,6 +24,28 @@ def test_create_instance():
     verifier.verify(3, expected_result=A(3))
 
 
+def test_type_coercing():
+    class A:
+        value: float
+
+        def __init__(self, value):
+            self.value = value
+
+        def __eq__(self, other):
+            if not isinstance(other, A):
+                return False
+            return self.value == other.value
+
+    def create_instance(x: int) -> A:
+        return A(x)
+
+    verifier = verifier_for(create_instance)
+
+    verifier.verify(1, expected_result=A(1))
+    verifier.verify(2, expected_result=A(2))
+    verifier.verify(3, expected_result=A(3))
+
+
 def test_deleted_field():
     class A:
         value: int

--- a/tests/test_solver_config.py
+++ b/tests/test_solver_config.py
@@ -55,7 +55,7 @@ def test_load_from_solver_config_file():
     assert entity_class_list.size() == 1
     assert entity_class_list.get(0) == get_java_type_for_python_type(Entity).getJavaClass()
     assert solver_config.getScoreDirectorFactoryConfig().getConstraintProviderClass() == \
-           my_constraints.__timefold_java_class  # noqa
+           my_constraints._timefold_java_class  # noqa
     assert solver_config.getTerminationConfig().getBestScoreLimit() == '0hard/0soft'
 
 

--- a/tests/test_user_error.py
+++ b/tests/test_user_error.py
@@ -111,3 +111,12 @@ def test_missing_enterprise():
         solver_config = SolverConfig(
             move_thread_count=MoveThreadCount.AUTO
         )._to_java_solver_config()
+
+    @nearby_distance_meter
+    def my_distance_meter(entity: Entity, value: str) -> float:
+        return 0.0
+
+    with pytest.raises(RequiresEnterpriseError, match=re.escape('nearby selection')):
+        solver_config = SolverConfig(
+            nearby_distance_meter_function=my_distance_meter
+        )._to_java_solver_config()

--- a/timefold-solver-python-core/src/main/python/config/config.py
+++ b/timefold-solver-python-core/src/main/python/config/config.py
@@ -104,6 +104,7 @@ class SolverConfig:
     environment_mode: Optional[EnvironmentMode] = field(default=EnvironmentMode.REPRODUCIBLE)
     random_seed: Optional[int] = field(default=None)
     move_thread_count: int | MoveThreadCount = field(default=MoveThreadCount.NONE)
+    nearby_distance_meter_function: Optional[Callable[[Any, Any], float]] = field(default=None)
     termination_config: Optional['TerminationConfig'] = field(default=None)
     score_director_factory_config: Optional['ScoreDirectorFactoryConfig'] = field(default=None)
     xml_source_text: Optional[str] = field(default=None)
@@ -148,6 +149,13 @@ class SolverConfig:
                     out.setMoveThreadCount(str(self.move_thread_count))
             elif out.getMoveThreadCount() is not None and not is_enterprise_installed():
                 raise RequiresEnterpriseError('multithreaded solving')
+
+            if self.nearby_distance_meter_function is not None:
+                if not is_enterprise_installed():
+                    raise RequiresEnterpriseError('nearby selection')
+                out.setNearbyDistanceMeterClass(get_class(self.nearby_distance_meter_function))
+            elif out.getNearbyDistanceMeterClass() is not None and not is_enterprise_installed():
+                raise RequiresEnterpriseError('nearby selection')
 
             if self.solution_class is not None:
                 from ai.timefold.solver.core.api.domain.solution import PlanningSolution as JavaPlanningSolution

--- a/timefold-solver-python-core/src/main/python/jpype_type_conversions.py
+++ b/timefold-solver-python-core/src/main/python/jpype_type_conversions.py
@@ -178,7 +178,7 @@ class PythonPentaPredicate:
 def _has_java_class(item):
     if isinstance(item, (JObject, int, str, bool)):
         return True
-    if hasattr(type(item), '__timefold_java_class'):
+    if hasattr(type(item), '_timefold_java_class'):
         return True
     return False
 


### PR DESCRIPTION
- Add automatic type coercion between int and float to prevent
      ClassCastExceptions when a function expecting float is given
      int and vice-versa
- Add register_java_class to set field holding the generated class
      and register the class in the SolverConfig classloader
- Rename field holding the generated class from __timefold_java_class
      to _timefold_java_class to prevent name-mangling
- Remove unused code

Depends on #31 