### PR TITLE
chore: Implement IncrementalScoreCalculator using classes instead of decorators

### DIFF
--- a/jpyinterpreter/src/main/java/ai/timefold/jpyinterpreter/builtins/FunctionBuiltinOperations.java
+++ b/jpyinterpreter/src/main/java/ai/timefold/jpyinterpreter/builtins/FunctionBuiltinOperations.java
@@ -4,10 +4,14 @@ import ai.timefold.jpyinterpreter.PythonLikeObject;
 import ai.timefold.jpyinterpreter.types.BoundPythonLikeFunction;
 import ai.timefold.jpyinterpreter.types.PythonLikeFunction;
 import ai.timefold.jpyinterpreter.types.PythonLikeType;
+import ai.timefold.jpyinterpreter.types.PythonNone;
 
 public class FunctionBuiltinOperations {
     public static PythonLikeObject bindFunctionToInstance(final PythonLikeFunction function, final PythonLikeObject instance,
             final PythonLikeType type) {
+        if (instance == PythonNone.INSTANCE) {
+            return function;
+        }
         return new BoundPythonLikeFunction(instance, function);
     }
 

--- a/tests/test_incremental_score_calculator.py
+++ b/tests/test_incremental_score_calculator.py
@@ -16,19 +16,19 @@ class Queen:
     column: int
     row: Annotated[Optional[int], PlanningVariable] = field(default=None)
 
-    def getColumnIndex(self):
+    def get_column_index(self):
         return self.column
 
-    def getRowIndex(self):
+    def get_row_index(self):
         if self.row is None:
             return -1
         return self.row
 
-    def getAscendingDiagonalIndex(self):
-        return self.getColumnIndex() + self.getRowIndex()
+    def get_ascending_diagonal_index(self):
+        return self.get_column_index() + self.get_row_index()
 
-    def getDescendingDiagonalIndex(self):
-        return self.getColumnIndex() - self.getRowIndex()
+    def get_descending_diagonal_index(self):
+        return self.get_column_index() - self.get_row_index()
 
     def __eq__(self, other):
         return self.code == other.code
@@ -48,14 +48,13 @@ class Solution:
 
 
 def test_constraint_match_disabled_incremental_score_calculator():
-    @incremental_score_calculator
-    class IncrementalScoreCalculator:
+    class NQueensIncrementalScoreCalculator(IncrementalScoreCalculator):
         score: int
         row_index_map: dict
         ascending_diagonal_index_map: dict
         descending_diagonal_index_map: dict
 
-        def resetWorkingSolution(self, working_solution: Solution):
+        def reset_working_solution(self, working_solution: Solution):
             n = working_solution.n
             self.row_index_map = dict()
             self.ascending_diagonal_index_map = dict()
@@ -71,22 +70,22 @@ def test_constraint_match_disabled_incremental_score_calculator():
             for queen in working_solution.queen_list:
                 self.insert(queen)
 
-        def beforeEntityAdded(self, entity: any):
+        def before_entity_added(self, entity: any):
             pass
 
-        def afterEntityAdded(self, entity: any):
+        def after_entity_added(self, entity: any):
             self.insert(entity)
 
-        def beforeVariableChanged(self, entity: any, variableName: str):
+        def before_variable_changed(self, entity: any, variableName: str):
             self.retract(entity)
 
-        def afterVariableChanged(self, entity: any, variableName: str):
+        def after_variable_changed(self, entity: any, variableName: str):
             self.insert(entity)
 
-        def beforeEntityRemoved(self, entity: any):
+        def before_entity_removed(self, entity: any):
             self.retract(entity)
 
-        def afterEntityRemoved(self, entity: any):
+        def after_entity_removed(self, entity: any):
             pass
 
         def insert(self, queen: Queen):
@@ -95,10 +94,10 @@ def test_constraint_match_disabled_incremental_score_calculator():
                 row_index_list = self.row_index_map[row_index]
                 self.score -= len(row_index_list)
                 row_index_list.append(queen)
-                ascending_diagonal_index_list = self.ascending_diagonal_index_map[queen.getAscendingDiagonalIndex()]
+                ascending_diagonal_index_list = self.ascending_diagonal_index_map[queen.get_ascending_diagonal_index()]
                 self.score -= len(ascending_diagonal_index_list)
                 ascending_diagonal_index_list.append(queen)
-                descending_diagonal_index_list = self.descending_diagonal_index_map[queen.getDescendingDiagonalIndex()]
+                descending_diagonal_index_list = self.descending_diagonal_index_map[queen.get_descending_diagonal_index()]
                 self.score -= len(descending_diagonal_index_list)
                 descending_diagonal_index_list.append(queen)
 
@@ -108,21 +107,21 @@ def test_constraint_match_disabled_incremental_score_calculator():
                 row_index_list = self.row_index_map[row_index]
                 row_index_list.remove(queen)
                 self.score += len(row_index_list)
-                ascending_diagonal_index_list = self.ascending_diagonal_index_map[queen.getAscendingDiagonalIndex()]
+                ascending_diagonal_index_list = self.ascending_diagonal_index_map[queen.get_ascending_diagonal_index()]
                 ascending_diagonal_index_list.remove(queen)
                 self.score += len(ascending_diagonal_index_list)
-                descending_diagonal_index_list = self.descending_diagonal_index_map[queen.getDescendingDiagonalIndex()]
+                descending_diagonal_index_list = self.descending_diagonal_index_map[queen.get_descending_diagonal_index()]
                 descending_diagonal_index_list.remove(queen)
                 self.score += len(descending_diagonal_index_list)
 
-        def calculateScore(self) -> HardSoftScore:
+        def calculate_score(self) -> HardSoftScore:
             return SimpleScore.of(self.score)
 
     solver_config = SolverConfig(
         solution_class=Solution,
         entity_class_list=[Queen],
         score_director_factory_config=ScoreDirectorFactoryConfig(
-            incremental_score_calculator_class=IncrementalScoreCalculator
+            incremental_score_calculator_class=NQueensIncrementalScoreCalculator
         ),
         termination_config=TerminationConfig(
             best_score_limit='0'
@@ -141,8 +140,8 @@ def test_constraint_match_disabled_incremental_score_calculator():
             right_queen = solution.queen_list[j]
             assert left_queen.row is not None and right_queen.row is not None
             assert left_queen.row != right_queen.row
-            assert left_queen.getAscendingDiagonalIndex() != right_queen.getAscendingDiagonalIndex()
-            assert left_queen.getDescendingDiagonalIndex() != right_queen.getDescendingDiagonalIndex()
+            assert left_queen.get_ascending_diagonal_index() != right_queen.get_ascending_diagonal_index()
+            assert left_queen.get_descending_diagonal_index() != right_queen.get_descending_diagonal_index()
 
 
 @pytest.mark.skip(reason="Special case where you want to convert all items of the list before returning."
@@ -150,13 +149,13 @@ def test_constraint_match_disabled_incremental_score_calculator():
                          "This feature is not that important, so skipping for now.")
 def test_constraint_match_enabled_incremental_score_calculator():
     @incremental_score_calculator
-    class IncrementalScoreCalculator:
+    class NQueensIncrementalScoreCalculator(ConstraintMatchAwareIncrementalScoreCalculator):
         score: int
         row_index_map: dict
         ascending_diagonal_index_map: dict
         descending_diagonal_index_map: dict
 
-        def resetWorkingSolution(self, working_solution: Solution, constraint_match_enabled=False):
+        def reset_working_solution(self, working_solution: Solution, constraint_match_enabled=False):
             n = working_solution.n
             self.row_index_map = dict()
             self.ascending_diagonal_index_map = dict()
@@ -172,22 +171,22 @@ def test_constraint_match_enabled_incremental_score_calculator():
             for queen in working_solution.queen_list:
                 self.insert(queen)
 
-        def beforeEntityAdded(self, entity: any):
+        def before_entity_added(self, entity: any):
             pass
 
-        def afterEntityAdded(self, entity: any):
+        def after_entity_added(self, entity: any):
             self.insert(entity)
 
-        def beforeVariableChanged(self, entity: any, variableName: str):
+        def before_variable_changed(self, entity: any, variableName: str):
             self.retract(entity)
 
-        def afterVariableChanged(self, entity: any, variableName: str):
+        def after_variable_changed(self, entity: any, variableName: str):
             self.insert(entity)
 
-        def beforeEntityRemoved(self, entity: any):
+        def before_entity_removed(self, entity: any):
             self.retract(entity)
 
-        def afterEntityRemoved(self, entity: any):
+        def after_entity_removed(self, entity: any):
             pass
 
         def insert(self, queen: Queen):
@@ -197,10 +196,10 @@ def test_constraint_match_enabled_incremental_score_calculator():
                 row_index_list = self.row_index_map[row_index]
                 self.score -= len(row_index_list)
                 row_index_list.append(queen)
-                ascending_diagonal_index_list = self.ascending_diagonal_index_map[queen.getAscendingDiagonalIndex()]
+                ascending_diagonal_index_list = self.ascending_diagonal_index_map[queen.get_ascending_diagonal_index()]
                 self.score -= len(ascending_diagonal_index_list)
                 ascending_diagonal_index_list.append(queen)
-                descending_diagonal_index_list = self.descending_diagonal_index_map[queen.getDescendingDiagonalIndex()]
+                descending_diagonal_index_list = self.descending_diagonal_index_map[queen.get_descending_diagonal_index()]
                 self.score -= len(descending_diagonal_index_list)
                 descending_diagonal_index_list.append(queen)
 
@@ -211,17 +210,17 @@ def test_constraint_match_enabled_incremental_score_calculator():
                 row_index_list = self.row_index_map[row_index]
                 row_index_list.remove(queen)
                 self.score += len(row_index_list)
-                ascending_diagonal_index_list = self.ascending_diagonal_index_map[queen.getAscendingDiagonalIndex()]
+                ascending_diagonal_index_list = self.ascending_diagonal_index_map[queen.get_ascending_diagonal_index()]
                 ascending_diagonal_index_list.remove(queen)
                 self.score += len(ascending_diagonal_index_list)
-                descending_diagonal_index_list = self.descending_diagonal_index_map[queen.getDescendingDiagonalIndex()]
+                descending_diagonal_index_list = self.descending_diagonal_index_map[queen.get_descending_diagonal_index()]
                 descending_diagonal_index_list.remove(queen)
                 self.score += len(descending_diagonal_index_list)
 
-        def calculateScore(self) -> HardSoftScore:
+        def calculate_score(self) -> HardSoftScore:
             return SimpleScore.of(self.score)
 
-        def getConstraintMatchTotals(self):
+        def get_constraint_match_totals(self):
             row_conflict_constraint_match_total = DefaultConstraintMatchTotal(
                 'NQueens',
                 'Row Conflict',
@@ -255,14 +254,14 @@ def test_constraint_match_enabled_incremental_score_calculator():
                 descending_diagonal_constraint_match_total
             ]
 
-        def getIndictmentMap(self):
+        def get_indictment_map(self):
             return None
 
     solver_config = SolverConfig(
         solution_class=Solution,
         entity_class_list=[Queen],
         score_director_factory_config=ScoreDirectorFactoryConfig(
-            incremental_score_calculator_class=IncrementalScoreCalculator
+            incremental_score_calculator_class=NQueensIncrementalScoreCalculator
         ),
         termination_config=TerminationConfig(
             best_score_limit='0'
@@ -282,8 +281,8 @@ def test_constraint_match_enabled_incremental_score_calculator():
             right_queen = solution.queen_list[j]
             assert left_queen.row is not None and right_queen.row is not None
             assert left_queen.row != right_queen.row
-            assert left_queen.getAscendingDiagonalIndex() != right_queen.getAscendingDiagonalIndex()
-            assert left_queen.getDescendingDiagonalIndex() != right_queen.getDescendingDiagonalIndex()
+            assert left_queen.get_ascending_diagonal_index() != right_queen.get_ascending_diagonal_index()
+            assert left_queen.get_descending_diagonal_index() != right_queen.get_descending_diagonal_index()
 
     score_manager = SolutionManager.create(solver_factory)
     constraint_match_total_map = score_manager.explain(solution).constraint_match_total_map
@@ -315,21 +314,19 @@ def test_constraint_match_enabled_incremental_score_calculator():
 
 
 def test_error_message_for_missing_methods():
-    with pytest.raises(ValueError, match=(
-            f"The following required methods are missing from @incremental_score_calculator class "
-            f".*IncrementalScoreCalculatorMissingMethods.*: "
-            f"\\['resetWorkingSolution', 'beforeEntityRemoved', 'afterEntityRemoved', 'calculateScore'\\]"
-    )):
+    with pytest.raises(TypeError):  # Exact error message from ABC changes between versions
         @incremental_score_calculator
-        class IncrementalScoreCalculatorMissingMethods:
-            def beforeEntityAdded(self, entity: any):
+        class IncrementalScoreCalculatorMissingMethods(IncrementalScoreCalculator):
+            def before_entity_added(self, entity):
                 pass
 
-            def afterEntityAdded(self, entity: any):
+            def after_entity_added(self, entity):
                 pass
 
-            def beforeVariableChanged(self, entity: any, variableName: str):
+            def before_variable_changed(self, entity, variable_name: str):
                 pass
 
-            def afterVariableChanged(self, entity: any, variableName: str):
+            def after_variable_changed(self, entity, variable_name: str):
                 pass
+
+        score_calculator = IncrementalScoreCalculatorMissingMethods()

--- a/timefold-solver-python-core/src/main/python/api/__init__.py
+++ b/timefold-solver-python-core/src/main/python/api/__init__.py
@@ -5,3 +5,4 @@ from ._solver_manager import *
 from ._solution_manager import *
 from ._score_director import *
 from ._variable_listener import *
+from ._incremental_score_calculator import *

--- a/timefold-solver-python-core/src/main/python/api/_incremental_score_calculator.py
+++ b/timefold-solver-python-core/src/main/python/api/_incremental_score_calculator.py
@@ -1,0 +1,164 @@
+from jpyinterpreter import add_java_interface
+from typing import TYPE_CHECKING
+from abc import ABC, abstractmethod
+
+
+@add_java_interface('ai.timefold.solver.core.api.score.calculator.IncrementalScoreCalculator')
+class IncrementalScoreCalculator(ABC):
+    @abstractmethod
+    def after_entity_added(self, entity) -> None:
+        ...
+
+    @abstractmethod
+    def after_entity_removed(self, entity) -> None:
+        ...
+
+    def after_list_variable_changed(self, entity, variable_name: str, start: int, end: int) -> None:
+        ...
+
+    def after_list_variable_element_assigned(self, variable_name: str, element) -> None:
+        ...
+
+    def after_list_variable_element_unassigned(self, variable_name: str, element) -> None:
+        ...
+
+    @abstractmethod
+    def after_variable_changed(self, entity, variable_name: str) -> None:
+        ...
+
+    @abstractmethod
+    def before_entity_added(self, entity) -> None:
+        ...
+
+    @abstractmethod
+    def before_entity_removed(self, entity) -> None:
+        ...
+
+    def before_list_variable_changed(self, entity, variable_name: str, start: int, end: int) -> None:
+        ...
+
+    def before_list_variable_element_assigned(self, variable_name: str, element) -> None:
+        ...
+
+    def before_list_variable_element_unassigned(self, variable_name: str, element) -> None:
+        ...
+
+    @abstractmethod
+    def before_variable_changed(self, entity, variable_name: str) -> None:
+        ...
+
+    @abstractmethod
+    def calculate_score(self):
+        ...
+
+    @abstractmethod
+    def reset_working_solution(self, solution) -> None:
+        ...
+
+
+@add_java_interface('ai.timefold.solver.core.api.score.calculator.ConstraintMatchAwareIncrementalScoreCalculator')
+class ConstraintMatchAwareIncrementalScoreCalculator(IncrementalScoreCalculator):
+    @abstractmethod
+    def get_constraint_match_totals(self) -> list:
+        ...
+
+    @abstractmethod
+    def get_indictment_map(self) -> dict:
+        ...
+
+    @abstractmethod
+    def reset_working_solution(self, solution, constraint_match_enabled=False) -> None:
+        ...
+
+
+if not TYPE_CHECKING:
+    # Use type(self).method(self, ...)
+    # Since if the arguments are typed, they might have different signatures and
+    # thus not override one another, meaning the generated interface method will
+    # call the original method and not the "overridden" one!
+    def afterEntityAdded(self, entity) -> None:
+        type(self).after_entity_added(self, entity)
+
+    IncrementalScoreCalculator.afterEntityAdded = afterEntityAdded
+
+    def afterEntityRemoved(self, entity) -> None:
+        type(self).after_entity_removed(self, entity)
+
+    IncrementalScoreCalculator.afterEntityRemoved = afterEntityRemoved
+
+    def afterListVariableChanged(self, entity, variable_name, start, end) -> None:
+        type(self).after_list_variable_changed(self, entity, variable_name, start, end)
+
+    IncrementalScoreCalculator.afterListVariableChanged = afterListVariableChanged
+
+    def afterListVariableElementAssigned(self, variable_name, element) -> None:
+        type(self).after_list_variable_element_assigned(self, variable_name, element)
+
+    IncrementalScoreCalculator.afterListVariableElementAssigned = afterListVariableElementAssigned
+
+    def afterListVariableElementUnassigned(self, variable_name, element) -> None:
+        type(self).after_list_variable_element_unassigned(self, variable_name, element)
+
+    IncrementalScoreCalculator.afterListVariableElementUnassigned = afterListVariableElementUnassigned
+
+    def afterVariableChanged(self, entity, variable_name) -> None:
+        type(self).after_variable_changed(self, entity, variable_name)
+
+    IncrementalScoreCalculator.afterVariableChanged = afterVariableChanged
+
+    def beforeEntityAdded(self, entity) -> None:
+        type(self).before_entity_added(self, entity)
+
+    IncrementalScoreCalculator.beforeEntityAdded = beforeEntityAdded
+
+    def beforeEntityRemoved(self, entity) -> None:
+        type(self).before_entity_removed(self, entity)
+
+    IncrementalScoreCalculator.beforeEntityRemoved = beforeEntityRemoved
+
+    def beforeListVariableChanged(self, entity, variable_name, start, end) -> None:
+        type(self).before_list_variable_changed(self, entity, variable_name, start, end)
+
+    IncrementalScoreCalculator.beforeListVariableChanged = beforeListVariableChanged
+
+    def beforeListVariableElementAssigned(self, variable_name, element) -> None:
+        type(self).before_list_variable_element_assigned(self, variable_name, element)
+
+    IncrementalScoreCalculator.beforeListVariableElementAssigned = beforeListVariableElementAssigned
+
+    def beforeListVariableElementUnassigned(self, variable_name, element) -> None:
+        type(self).before_list_variable_element_unassigned(self, variable_name, element)
+
+    IncrementalScoreCalculator.beforeListVariableElementUnassigned = beforeListVariableElementUnassigned
+
+    def beforeVariableChanged(self, entity, variable_name) -> None:
+        type(self).before_variable_changed(self, entity, variable_name)
+
+    IncrementalScoreCalculator.beforeVariableChanged = beforeVariableChanged
+
+    def calculateScore(self):
+        return type(self).calculate_score(self)
+
+    IncrementalScoreCalculator.calculateScore = calculateScore
+
+    def resetWorkingSolution(self, solution) -> None:
+        type(self).reset_working_solution(self, solution)
+
+    IncrementalScoreCalculator.resetWorkingSolution = resetWorkingSolution
+
+    def getConstraintMatchTotals(self) -> list:
+        return type(self).get_constraint_match_totals(self)
+
+    ConstraintMatchAwareIncrementalScoreCalculator.getConstraintMatchTotals = getConstraintMatchTotals
+
+    def getIndictmentMap(self) -> dict:
+        return type(self).get_indictment_map(self)
+
+    ConstraintMatchAwareIncrementalScoreCalculator.getIndictmentMap = getIndictmentMap
+
+    def resetWorkingSolution(self, solution, constraint_match_enabled=False) -> None:
+        type(self).reset_working_solution(self, solution, constraint_match_enabled)
+
+    ConstraintMatchAwareIncrementalScoreCalculator.resetWorkingSolution = resetWorkingSolution
+
+__all__ = ['IncrementalScoreCalculator', 'ConstraintMatchAwareIncrementalScoreCalculator']

--- a/timefold-solver-python-core/src/main/python/api/_variable_listener.py
+++ b/timefold-solver-python-core/src/main/python/api/_variable_listener.py
@@ -42,48 +42,48 @@ class VariableListener:
 if not TYPE_CHECKING:  # We do not want these methods to appear in the API
     def afterEntityAdded(self, java_score_director, entity) -> None:
         score_director = ScoreDirector(java_score_director)
-        self.after_entity_added(score_director, entity)
+        type(self).after_entity_added(self, score_director, entity)
 
     VariableListener.afterEntityAdded = afterEntityAdded
 
     def afterEntityRemoved(self, java_score_director, entity) -> None:
         score_director = ScoreDirector(java_score_director)
-        self.after_entity_removed(score_director, entity)
+        type(self).after_entity_removed(self, score_director, entity)
 
     VariableListener.afterEntityRemoved = afterEntityRemoved
 
     def beforeEntityAdded(self, java_score_director, entity) -> None:
         score_director = ScoreDirector(java_score_director)
-        self.before_entity_added(score_director, entity)
+        type(self).before_entity_added(self, score_director, entity)
 
     VariableListener.beforeEntityAdded = beforeEntityAdded
 
     def beforeEntityRemoved(self, java_score_director, entity) -> None:
         score_director = ScoreDirector(java_score_director)
-        self.before_entity_removed(score_director, entity)
+        type(self).before_entity_removed(self, score_director, entity)
 
     VariableListener.beforeEntityRemoved = beforeEntityRemoved
 
     def resetWorkingSolution(self, java_score_director) -> None:
         score_director = ScoreDirector(java_score_director)
-        self.reset_working_solution(score_director)
+        type(self).reset_working_solution(self, score_director)
 
     VariableListener.resetWorkingSolution = resetWorkingSolution
 
     def afterVariableChanged(self, java_score_director, entity) -> None:
         score_director = ScoreDirector(java_score_director)
-        self.after_variable_changed(score_director, entity)
+        type(self).after_variable_changed(self, score_director, entity)
 
     VariableListener.afterVariableChanged = afterVariableChanged
 
     def beforeVariableChanged(self, java_score_director, entity) -> None:
         score_director = ScoreDirector(java_score_director)
-        self.before_variable_changed(score_director, entity)
+        type(self).before_variable_changed(self, score_director, entity)
 
     VariableListener.beforeVariableChanged = beforeVariableChanged
 
     def requiresUniqueEntityEvents(self) -> bool:
-        return self.requires_unique_entity_events()
+        return type(self).requires_unique_entity_events(self)
 
     VariableListener.requiresUniqueEntityEvents = requiresUniqueEntityEvents
 


### PR DESCRIPTION
- Since there can only be one function signature in Python, and Java allows many, it might be the case that the top function signature in Python does not match its parent's function signature. Since the interface calls the parent's function signature, the wrong method would be called. To prevent this, we need to look up the 'canonical' method of the type, which is conveniently stored as an attribute on the type.

- Fix a bug in function __get__ descriptor; in particular, when called on a type, it should return the unbounded function instead of binding the function to the type.

- Make the ABC check less strict. In particular, only collections.abc and Protocol are banned, since collections.abc contain classes that should be Protocols but are instead ABC, and Protocols only define the structure and do not play a part in type hierarchy.