### PR TITLE
chore: Handle forward references, repeatable annotations, and use str enums

### DIFF
--- a/jpyinterpreter/src/main/java/ai/timefold/jpyinterpreter/PythonCompiledFunction.java
+++ b/jpyinterpreter/src/main/java/ai/timefold/jpyinterpreter/PythonCompiledFunction.java
@@ -208,12 +208,16 @@ public class PythonCompiledFunction {
         return (Class) parameterTypeList.get(variableIndex).getJavaClassOrDefault(PythonLikeObject.class);
     }
 
+    private static String getParameterJavaClassName(List<PythonLikeType> parameterTypeList, int variableIndex) {
+        return parameterTypeList.get(variableIndex).getJavaTypeInternalName();
+    }
+
     @SuppressWarnings({ "unchecked", "rawtypes" })
     public BiFunction<PythonLikeTuple, PythonLikeDict, ArgumentSpec<PythonLikeObject>> getArgumentSpecMapper() {
         return (defaultPositionalArguments, defaultKeywordArguments) -> {
             ArgumentSpec<PythonLikeObject> out = ArgumentSpec.forFunctionReturning(qualifiedName, getReturnType()
-                    .map(type -> (Class) type.getJavaClassOrDefault(PythonLikeObject.class))
-                    .orElse(PythonLikeObject.class));
+                    .map(PythonLikeType::getJavaTypeInternalName)
+                    .orElse(PythonLikeObject.class.getName()));
 
             int variableIndex = 0;
             int defaultPositionalStartIndex = co_argcount - defaultPositionalArguments.size();
@@ -226,23 +230,23 @@ public class PythonCompiledFunction {
             for (; variableIndex < co_posonlyargcount; variableIndex++) {
                 if (variableIndex >= defaultPositionalStartIndex) {
                     out = out.addPositionalOnlyArgument(co_varnames.get(variableIndex),
-                            getParameterJavaClass(parameterTypeList, variableIndex),
+                            getParameterJavaClassName(parameterTypeList, variableIndex),
                             defaultPositionalArguments.get(
                                     variableIndex - defaultPositionalStartIndex));
                 } else {
                     out = out.addPositionalOnlyArgument(co_varnames.get(variableIndex),
-                            getParameterJavaClass(parameterTypeList, variableIndex));
+                            getParameterJavaClassName(parameterTypeList, variableIndex));
                 }
             }
 
             for (; variableIndex < co_argcount; variableIndex++) {
                 if (variableIndex >= defaultPositionalStartIndex) {
                     out = out.addArgument(co_varnames.get(variableIndex),
-                            getParameterJavaClass(parameterTypeList, variableIndex),
+                            getParameterJavaClassName(parameterTypeList, variableIndex),
                             defaultPositionalArguments.get(variableIndex - defaultPositionalStartIndex));
                 } else {
                     out = out.addArgument(co_varnames.get(variableIndex),
-                            getParameterJavaClass(parameterTypeList, variableIndex));
+                            getParameterJavaClassName(parameterTypeList, variableIndex));
                 }
             }
 
@@ -251,11 +255,11 @@ public class PythonCompiledFunction {
                         defaultKeywordArguments.get(PythonString.valueOf(co_varnames.get(variableIndex)));
                 if (maybeDefault != null) {
                     out = out.addKeywordOnlyArgument(co_varnames.get(variableIndex),
-                            getParameterJavaClass(parameterTypeList, variableIndex),
+                            getParameterJavaClassName(parameterTypeList, variableIndex),
                             maybeDefault);
                 } else {
                     out = out.addKeywordOnlyArgument(co_varnames.get(variableIndex),
-                            getParameterJavaClass(parameterTypeList, variableIndex));
+                            getParameterJavaClassName(parameterTypeList, variableIndex));
                 }
                 variableIndex++;
             }

--- a/jpyinterpreter/src/main/java/ai/timefold/jpyinterpreter/PythonOverloadImplementor.java
+++ b/jpyinterpreter/src/main/java/ai/timefold/jpyinterpreter/PythonOverloadImplementor.java
@@ -475,7 +475,7 @@ public class PythonOverloadImplementor {
                 methodVisitor.visitVarInsn(Opcodes.ALOAD, 1);
             }
             methodVisitor.visitVarInsn(Opcodes.ALOAD, 2);
-            KnownCallImplementor.callUnpackListAndMap(functionSignature.getDefaultArgumentHolderClass(),
+            KnownCallImplementor.callUnpackListAndMap(functionSignature.getDefaultArgumentHolderClassInternalName(),
                     functionSignature.getMethodDescriptor(), methodVisitor);
             methodVisitor.visitInsn(Opcodes.ARETURN);
         }

--- a/jpyinterpreter/src/main/java/ai/timefold/jpyinterpreter/TypeHint.java
+++ b/jpyinterpreter/src/main/java/ai/timefold/jpyinterpreter/TypeHint.java
@@ -6,20 +6,25 @@ import java.util.List;
 
 import ai.timefold.jpyinterpreter.types.PythonLikeType;
 
-public record TypeHint(PythonLikeType type, List<AnnotationMetadata> annotationList, TypeHint[] genericArgs) {
+public record TypeHint(PythonLikeType type, List<AnnotationMetadata> annotationList, TypeHint[] genericArgs,
+        PythonLikeType javaGetterType) {
     public TypeHint {
         annotationList = Collections.unmodifiableList(annotationList);
     }
 
     public TypeHint(PythonLikeType type, List<AnnotationMetadata> annotationList) {
-        this(type, annotationList, null);
+        this(type, annotationList, null, type);
+    }
+
+    public TypeHint(PythonLikeType type, List<AnnotationMetadata> annotationList, PythonLikeType javaGetterType) {
+        this(type, annotationList, null, javaGetterType);
     }
 
     public TypeHint addAnnotations(List<AnnotationMetadata> addedAnnotations) {
         List<AnnotationMetadata> combinedAnnotations = new ArrayList<>(annotationList.size() + addedAnnotations.size());
         combinedAnnotations.addAll(annotationList);
         combinedAnnotations.addAll(addedAnnotations);
-        return new TypeHint(type, combinedAnnotations, genericArgs);
+        return new TypeHint(type, combinedAnnotations, genericArgs, javaGetterType);
     }
 
     public static TypeHint withoutAnnotations(PythonLikeType type) {

--- a/jpyinterpreter/src/main/java/ai/timefold/jpyinterpreter/implementors/KnownCallImplementor.java
+++ b/jpyinterpreter/src/main/java/ai/timefold/jpyinterpreter/implementors/KnownCallImplementor.java
@@ -113,14 +113,15 @@ public class KnownCallImplementor {
         // Now load and typecheck the local variables
         for (int i = 0; i < Math.min(specPositionalArgumentCount, argumentCount); i++) {
             localVariableHelper.readTemp(methodVisitor, Type.getType(PythonLikeObject.class), argumentLocals[i]);
-            methodVisitor.visitLdcInsn(Type.getType(pythonFunctionSignature.getArgumentSpec().getArgumentType(i)));
+            methodVisitor.visitLdcInsn(
+                    Type.getType("L" + pythonFunctionSignature.getArgumentSpec().getArgumentTypeInternalName(i) + ";"));
             methodVisitor.visitMethodInsn(Opcodes.INVOKESTATIC, Type.getInternalName(JavaPythonTypeConversionImplementor.class),
                     "coerceToType", Type.getMethodDescriptor(Type.getType(Object.class),
                             Type.getType(PythonLikeObject.class),
                             Type.getType(Class.class)),
                     false);
             methodVisitor.visitTypeInsn(Opcodes.CHECKCAST,
-                    Type.getInternalName(pythonFunctionSignature.getArgumentSpec().getArgumentType(i)));
+                    pythonFunctionSignature.getArgumentSpec().getArgumentTypeInternalName(i));
         }
 
         // Load any arguments missing values
@@ -129,9 +130,9 @@ public class KnownCallImplementor {
                 methodVisitor.visitInsn(Opcodes.ACONST_NULL);
             } else {
                 methodVisitor.visitFieldInsn(Opcodes.GETSTATIC,
-                        Type.getInternalName(pythonFunctionSignature.getDefaultArgumentHolderClass()),
+                        pythonFunctionSignature.getDefaultArgumentHolderClassInternalName(),
                         PythonDefaultArgumentImplementor.getConstantName(i),
-                        Type.getDescriptor(pythonFunctionSignature.getArgumentSpec().getArgumentType(i)));
+                        "L" + pythonFunctionSignature.getArgumentSpec().getArgumentTypeInternalName(i) + ";");
             }
         }
 
@@ -245,9 +246,9 @@ public class KnownCallImplementor {
                 methodVisitor.visitInsn(Opcodes.ACONST_NULL);
             } else {
                 methodVisitor.visitFieldInsn(Opcodes.GETSTATIC,
-                        Type.getInternalName(pythonFunctionSignature.getDefaultArgumentHolderClass()),
+                        pythonFunctionSignature.getDefaultArgumentHolderClassInternalName(),
                         PythonDefaultArgumentImplementor.getConstantName(argumentIndex - defaultOffset),
-                        Type.getDescriptor(pythonFunctionSignature.getArgumentSpec().getArgumentType(argumentIndex)));
+                        "L" + pythonFunctionSignature.getArgumentSpec().getArgumentTypeInternalName(argumentIndex) + ";");
             }
             localVariableHelper.writeTemp(methodVisitor, Type.getType(PythonLikeObject.class),
                     argumentLocals[argumentIndex]);
@@ -285,14 +286,15 @@ public class KnownCallImplementor {
         // Load arguments in proper order and typecast them
         for (int i = 0; i < specTotalArgumentCount; i++) {
             localVariableHelper.readTemp(methodVisitor, Type.getType(PythonLikeObject.class), argumentLocals[i]);
-            methodVisitor.visitLdcInsn(Type.getType(pythonFunctionSignature.getArgumentSpec().getArgumentType(i)));
+            methodVisitor.visitLdcInsn(
+                    Type.getType("L" + pythonFunctionSignature.getArgumentSpec().getArgumentTypeInternalName(i) + ";"));
             methodVisitor.visitMethodInsn(Opcodes.INVOKESTATIC, Type.getInternalName(JavaPythonTypeConversionImplementor.class),
                     "coerceToType", Type.getMethodDescriptor(Type.getType(Object.class),
                             Type.getType(PythonLikeObject.class),
                             Type.getType(Class.class)),
                     false);
             methodVisitor.visitTypeInsn(Opcodes.CHECKCAST,
-                    Type.getInternalName(pythonFunctionSignature.getArgumentSpec().getArgumentType(i)));
+                    pythonFunctionSignature.getArgumentSpec().getArgumentTypeInternalName(i));
         }
 
         pythonFunctionSignature.getMethodDescriptor().callMethod(methodVisitor);
@@ -337,7 +339,7 @@ public class KnownCallImplementor {
         Type[] descriptorParameterTypes = pythonFunctionSignature.getMethodDescriptor().getParameterTypes();
 
         if (argumentCount < descriptorParameterTypes.length
-                && pythonFunctionSignature.getDefaultArgumentHolderClass() == null) {
+                && pythonFunctionSignature.getDefaultArgumentHolderClassInternalName() == null) {
             throw new IllegalStateException(
                     "Cannot call " + pythonFunctionSignature + " because there are not enough arguments");
         }
@@ -355,7 +357,7 @@ public class KnownCallImplementor {
         }
 
         // TOS is a tuple of keys
-        methodVisitor.visitTypeInsn(Opcodes.NEW, Type.getInternalName(pythonFunctionSignature.getDefaultArgumentHolderClass()));
+        methodVisitor.visitTypeInsn(Opcodes.NEW, pythonFunctionSignature.getDefaultArgumentHolderClassInternalName());
         methodVisitor.visitInsn(Opcodes.DUP_X1);
         methodVisitor.visitInsn(Opcodes.SWAP);
 
@@ -374,7 +376,7 @@ public class KnownCallImplementor {
 
         // Stack is defaults (uninitialized), keys, positional arguments
         methodVisitor.visitMethodInsn(Opcodes.INVOKESPECIAL,
-                Type.getInternalName(pythonFunctionSignature.getDefaultArgumentHolderClass()),
+                pythonFunctionSignature.getDefaultArgumentHolderClassInternalName(),
                 "<init>", Type.getMethodDescriptor(Type.VOID_TYPE, Type.getType(PythonLikeTuple.class), Type.INT_TYPE),
                 false);
 
@@ -402,7 +404,7 @@ public class KnownCallImplementor {
                 methodVisitor.visitLabel(doneGettingType);
             }
             methodVisitor.visitMethodInsn(Opcodes.INVOKEVIRTUAL,
-                    Type.getInternalName(pythonFunctionSignature.getDefaultArgumentHolderClass()),
+                    pythonFunctionSignature.getDefaultArgumentHolderClassInternalName(),
                     "addArgument", Type.getMethodDescriptor(Type.VOID_TYPE, Type.getType(PythonLikeObject.class)),
                     false);
         }
@@ -410,7 +412,7 @@ public class KnownCallImplementor {
         for (int i = 0; i < descriptorParameterTypes.length; i++) {
             methodVisitor.visitInsn(Opcodes.DUP);
             methodVisitor.visitFieldInsn(Opcodes.GETFIELD,
-                    Type.getInternalName(pythonFunctionSignature.getDefaultArgumentHolderClass()),
+                    pythonFunctionSignature.getDefaultArgumentHolderClassInternalName(),
                     PythonDefaultArgumentImplementor.getArgumentName(i),
                     descriptorParameterTypes[i].getDescriptor());
             methodVisitor.visitInsn(Opcodes.SWAP);
@@ -420,7 +422,7 @@ public class KnownCallImplementor {
         pythonFunctionSignature.getMethodDescriptor().callMethod(methodVisitor);
     }
 
-    public static void callUnpackListAndMap(Class<?> defaultArgumentHolderClass, MethodDescriptor methodDescriptor,
+    public static void callUnpackListAndMap(String defaultArgumentHolderClassInternalName, MethodDescriptor methodDescriptor,
             MethodVisitor methodVisitor) {
         Type[] descriptorParameterTypes = methodDescriptor.getParameterTypes();
 
@@ -457,7 +459,7 @@ public class KnownCallImplementor {
             // stack is bound-method, pos, keywords
         }
 
-        methodVisitor.visitFieldInsn(Opcodes.GETSTATIC, Type.getInternalName(defaultArgumentHolderClass),
+        methodVisitor.visitFieldInsn(Opcodes.GETSTATIC, defaultArgumentHolderClassInternalName,
                 PythonDefaultArgumentImplementor.ARGUMENT_SPEC_STATIC_FIELD_NAME,
                 Type.getDescriptor(ArgumentSpec.class));
 

--- a/jpyinterpreter/src/main/java/ai/timefold/jpyinterpreter/opcodes/descriptor/MetaOpDescriptor.java
+++ b/jpyinterpreter/src/main/java/ai/timefold/jpyinterpreter/opcodes/descriptor/MetaOpDescriptor.java
@@ -29,19 +29,24 @@ public enum MetaOpDescriptor implements OpcodeDescriptor {
     CALL_INTRINSIC_1(UnaryIntrinsicFunction::lookup),
 
     // TODO
-    EXTENDED_ARG(null),
+    EXTENDED_ARG(ignored -> {
+        throw new UnsupportedOperationException("EXTENDED_ARG");
+    }),
 
     /**
      * Pushes builtins.__build_class__() onto the stack.
      * It is later called by CALL_FUNCTION to construct a class.
      */
-    LOAD_BUILD_CLASS(null),
+    LOAD_BUILD_CLASS(ignored -> {
+        throw new UnsupportedOperationException("LOAD_BUILD_CLASS");
+    }),
 
     /**
      * Checks whether __annotations__ is defined in locals(), if not it is set up to an empty dict. This opcode is only
      * emitted if a class or module body contains variable annotations statically.
+     * TODO: Properly implement this
      */
-    SETUP_ANNOTATIONS(null);
+    SETUP_ANNOTATIONS(NopOpcode::new);
 
     private final VersionMapping versionLookup;
 

--- a/jpyinterpreter/src/main/java/ai/timefold/jpyinterpreter/opcodes/descriptor/VersionMapping.java
+++ b/jpyinterpreter/src/main/java/ai/timefold/jpyinterpreter/opcodes/descriptor/VersionMapping.java
@@ -1,6 +1,7 @@
 package ai.timefold.jpyinterpreter.opcodes.descriptor;
 
 import java.util.NavigableMap;
+import java.util.Objects;
 import java.util.TreeMap;
 import java.util.function.BiFunction;
 import java.util.function.Function;
@@ -28,12 +29,12 @@ public final class VersionMapping {
 
     public static VersionMapping constantMapping(Function<PythonBytecodeInstruction, Opcode> mapper) {
         return new VersionMapping()
-                .map(PythonVersion.MINIMUM_PYTHON_VERSION, mapper);
+                .map(PythonVersion.MINIMUM_PYTHON_VERSION, Objects.requireNonNull(mapper));
     }
 
     public static VersionMapping constantMapping(BiFunction<PythonBytecodeInstruction, PythonVersion, Opcode> mapper) {
         return new VersionMapping()
-                .map(PythonVersion.MINIMUM_PYTHON_VERSION, mapper);
+                .map(PythonVersion.MINIMUM_PYTHON_VERSION, Objects.requireNonNull(mapper));
     }
 
     public VersionMapping map(PythonVersion version, Function<PythonBytecodeInstruction, Opcode> mapper) {

--- a/jpyinterpreter/src/main/java/ai/timefold/jpyinterpreter/types/PythonString.java
+++ b/jpyinterpreter/src/main/java/ai/timefold/jpyinterpreter/types/PythonString.java
@@ -135,7 +135,7 @@ public class PythonString extends AbstractPythonLikeObject implements PythonLike
         BuiltinTypes.STRING_TYPE.addMethod("find", PythonString.class.getMethod("findSubstringIndex", PythonString.class,
                 PythonInteger.class, PythonInteger.class));
 
-        BuiltinTypes.STRING_TYPE.addMethod("format", ArgumentSpec.forFunctionReturning("format", PythonString.class)
+        BuiltinTypes.STRING_TYPE.addMethod("format", ArgumentSpec.forFunctionReturning("format", PythonString.class.getName())
                 .addExtraPositionalVarArgument("vargs")
                 .addExtraKeywordVarArgument("kwargs")
                 .asPythonFunctionSignature(PythonString.class.getMethod("format", List.class, Map.class)));

--- a/jpyinterpreter/src/main/java/ai/timefold/jpyinterpreter/types/datetime/PythonDate.java
+++ b/jpyinterpreter/src/main/java/ai/timefold/jpyinterpreter/types/datetime/PythonDate.java
@@ -62,10 +62,10 @@ public class PythonDate<T extends PythonDate<?>> extends AbstractPythonLikeObjec
 
     private static void registerMethods() throws NoSuchMethodException {
         // Constructor
-        DATE_TYPE.addConstructor(ArgumentSpec.forFunctionReturning("date", PythonDate.class)
-                .addArgument("year", PythonInteger.class)
-                .addArgument("month", PythonInteger.class)
-                .addArgument("day", PythonInteger.class)
+        DATE_TYPE.addConstructor(ArgumentSpec.forFunctionReturning("date", PythonDate.class.getName())
+                .addArgument("year", PythonInteger.class.getName())
+                .addArgument("month", PythonInteger.class.getName())
+                .addArgument("day", PythonInteger.class.getName())
                 .asStaticPythonFunctionSignature(PythonDate.class.getMethod("of", PythonInteger.class,
                         PythonInteger.class, PythonInteger.class)));
         // Unary Operators
@@ -82,10 +82,10 @@ public class PythonDate<T extends PythonDate<?>> extends AbstractPythonLikeObjec
 
         // Methods
         DATE_TYPE.addMethod("replace",
-                ArgumentSpec.forFunctionReturning("replace", PythonDate.class)
-                        .addNullableArgument("year", PythonInteger.class)
-                        .addNullableArgument("month", PythonInteger.class)
-                        .addNullableArgument("day", PythonInteger.class)
+                ArgumentSpec.forFunctionReturning("replace", PythonDate.class.getName())
+                        .addNullableArgument("year", PythonInteger.class.getName())
+                        .addNullableArgument("month", PythonInteger.class.getName())
+                        .addNullableArgument("day", PythonInteger.class.getName())
                         .asPythonFunctionSignature(PythonDate.class.getMethod("replace", PythonInteger.class,
                                 PythonInteger.class, PythonInteger.class)));
         DATE_TYPE.addMethod("timetuple",
@@ -113,39 +113,39 @@ public class PythonDate<T extends PythonDate<?>> extends AbstractPythonLikeObjec
 
         // Class methods
         DATE_TYPE.addMethod("today",
-                ArgumentSpec.forFunctionReturning("today", PythonDate.class)
-                        .addArgument("date_type", PythonLikeType.class)
+                ArgumentSpec.forFunctionReturning("today", PythonDate.class.getName())
+                        .addArgument("date_type", PythonLikeType.class.getName())
                         .asClassPythonFunctionSignature(PythonDate.class.getMethod("today",
                                 PythonLikeType.class)));
 
         DATE_TYPE.addMethod("fromtimestamp",
-                ArgumentSpec.forFunctionReturning("fromtimestamp", PythonDate.class)
-                        .addArgument("date_type", PythonLikeType.class)
-                        .addArgument("timestamp", PythonNumber.class)
+                ArgumentSpec.forFunctionReturning("fromtimestamp", PythonDate.class.getName())
+                        .addArgument("date_type", PythonLikeType.class.getName())
+                        .addArgument("timestamp", PythonNumber.class.getName())
                         .asClassPythonFunctionSignature(PythonDate.class.getMethod("from_timestamp",
                                 PythonLikeType.class,
                                 PythonNumber.class)));
 
         DATE_TYPE.addMethod("fromordinal",
-                ArgumentSpec.forFunctionReturning("fromordinal", PythonDate.class)
-                        .addArgument("date_type", PythonLikeType.class)
-                        .addArgument("ordinal", PythonInteger.class)
+                ArgumentSpec.forFunctionReturning("fromordinal", PythonDate.class.getName())
+                        .addArgument("date_type", PythonLikeType.class.getName())
+                        .addArgument("ordinal", PythonInteger.class.getName())
                         .asClassPythonFunctionSignature(PythonDate.class.getMethod("from_ordinal",
                                 PythonLikeType.class, PythonInteger.class)));
 
         DATE_TYPE.addMethod("fromisoformat",
-                ArgumentSpec.forFunctionReturning("fromisoformat", PythonDate.class)
-                        .addArgument("date_type", PythonLikeType.class)
-                        .addArgument("date_string", PythonString.class)
+                ArgumentSpec.forFunctionReturning("fromisoformat", PythonDate.class.getName())
+                        .addArgument("date_type", PythonLikeType.class.getName())
+                        .addArgument("date_string", PythonString.class.getName())
                         .asClassPythonFunctionSignature(PythonDate.class.getMethod("from_iso_format",
                                 PythonLikeType.class, PythonString.class)));
 
         DATE_TYPE.addMethod("fromisocalendar",
-                ArgumentSpec.forFunctionReturning("fromisocalendar", PythonDate.class)
-                        .addArgument("date_type", PythonLikeType.class)
-                        .addArgument("year", PythonInteger.class)
-                        .addArgument("month", PythonInteger.class)
-                        .addArgument("day", PythonInteger.class)
+                ArgumentSpec.forFunctionReturning("fromisocalendar", PythonDate.class.getName())
+                        .addArgument("date_type", PythonLikeType.class.getName())
+                        .addArgument("year", PythonInteger.class.getName())
+                        .addArgument("month", PythonInteger.class.getName())
+                        .addArgument("day", PythonInteger.class.getName())
                         .asClassPythonFunctionSignature(PythonDate.class.getMethod("from_iso_calendar", PythonLikeType.class,
                                 PythonInteger.class, PythonInteger.class, PythonInteger.class)));
     }

--- a/jpyinterpreter/src/main/java/ai/timefold/jpyinterpreter/types/datetime/PythonDateTime.java
+++ b/jpyinterpreter/src/main/java/ai/timefold/jpyinterpreter/types/datetime/PythonDateTime.java
@@ -77,16 +77,16 @@ public class PythonDateTime extends PythonDate<PythonDateTime> implements Planni
 
     private static void registerMethods() throws NoSuchMethodException {
         // Constructor
-        DATE_TIME_TYPE.addConstructor(ArgumentSpec.forFunctionReturning("datetime", PythonDateTime.class)
-                .addArgument("year", PythonInteger.class)
-                .addArgument("month", PythonInteger.class)
-                .addArgument("day", PythonInteger.class)
-                .addArgument("hour", PythonInteger.class, PythonInteger.ZERO)
-                .addArgument("minute", PythonInteger.class, PythonInteger.ZERO)
-                .addArgument("second", PythonInteger.class, PythonInteger.ZERO)
-                .addArgument("microsecond", PythonInteger.class, PythonInteger.ZERO)
-                .addArgument("tzinfo", PythonLikeObject.class, PythonNone.INSTANCE)
-                .addKeywordOnlyArgument("fold", PythonInteger.class, PythonInteger.ZERO)
+        DATE_TIME_TYPE.addConstructor(ArgumentSpec.forFunctionReturning("datetime", PythonDateTime.class.getName())
+                .addArgument("year", PythonInteger.class.getName())
+                .addArgument("month", PythonInteger.class.getName())
+                .addArgument("day", PythonInteger.class.getName())
+                .addArgument("hour", PythonInteger.class.getName(), PythonInteger.ZERO)
+                .addArgument("minute", PythonInteger.class.getName(), PythonInteger.ZERO)
+                .addArgument("second", PythonInteger.class.getName(), PythonInteger.ZERO)
+                .addArgument("microsecond", PythonInteger.class.getName(), PythonInteger.ZERO)
+                .addArgument("tzinfo", PythonLikeObject.class.getName(), PythonNone.INSTANCE)
+                .addKeywordOnlyArgument("fold", PythonInteger.class.getName(), PythonInteger.ZERO)
                 .asPythonFunctionSignature(
                         PythonDateTime.class.getMethod("of", PythonInteger.class, PythonInteger.class, PythonInteger.class,
                                 PythonInteger.class, PythonInteger.class, PythonInteger.class, PythonInteger.class,
@@ -95,45 +95,45 @@ public class PythonDateTime extends PythonDate<PythonDateTime> implements Planni
         // Class methods
         // Date handles today,
         DATE_TIME_TYPE.addMethod("now",
-                ArgumentSpec.forFunctionReturning("now", PythonDateTime.class)
-                        .addArgument("datetime_type", PythonLikeType.class)
-                        .addArgument("tzinfo", PythonLikeObject.class, PythonNone.INSTANCE)
+                ArgumentSpec.forFunctionReturning("now", PythonDateTime.class.getName())
+                        .addArgument("datetime_type", PythonLikeType.class.getName())
+                        .addArgument("tzinfo", PythonLikeObject.class.getName(), PythonNone.INSTANCE)
                         .asClassPythonFunctionSignature(
                                 PythonDateTime.class.getMethod("now",
                                         PythonLikeType.class,
                                         PythonLikeObject.class)));
 
         DATE_TIME_TYPE.addMethod("utcnow",
-                ArgumentSpec.forFunctionReturning("now", PythonDateTime.class)
-                        .addArgument("datetime_type", PythonLikeType.class)
+                ArgumentSpec.forFunctionReturning("now", PythonDateTime.class.getName())
+                        .addArgument("datetime_type", PythonLikeType.class.getName())
                         .asClassPythonFunctionSignature(
                                 PythonDateTime.class.getMethod("utc_now",
                                         PythonLikeType.class)));
 
         DATE_TIME_TYPE.addMethod("fromtimestamp",
-                ArgumentSpec.forFunctionReturning("fromtimestamp", PythonDate.class)
-                        .addArgument("date_type", PythonLikeType.class)
-                        .addArgument("timestamp", PythonNumber.class)
-                        .addArgument("tzinfo", PythonLikeObject.class, PythonNone.INSTANCE)
+                ArgumentSpec.forFunctionReturning("fromtimestamp", PythonDate.class.getName())
+                        .addArgument("date_type", PythonLikeType.class.getName())
+                        .addArgument("timestamp", PythonNumber.class.getName())
+                        .addArgument("tzinfo", PythonLikeObject.class.getName(), PythonNone.INSTANCE)
                         .asClassPythonFunctionSignature(PythonDateTime.class.getMethod("from_timestamp",
                                 PythonLikeType.class,
                                 PythonNumber.class,
                                 PythonLikeObject.class)));
 
         DATE_TIME_TYPE.addMethod("utcfromtimestamp",
-                ArgumentSpec.forFunctionReturning("utcfromtimestamp", PythonDate.class)
-                        .addArgument("date_type", PythonLikeType.class)
-                        .addArgument("timestamp", PythonNumber.class)
+                ArgumentSpec.forFunctionReturning("utcfromtimestamp", PythonDate.class.getName())
+                        .addArgument("date_type", PythonLikeType.class.getName())
+                        .addArgument("timestamp", PythonNumber.class.getName())
                         .asClassPythonFunctionSignature(PythonDateTime.class.getMethod("utc_from_timestamp",
                                 PythonLikeType.class,
                                 PythonNumber.class)));
 
         DATE_TIME_TYPE.addMethod("combine",
-                ArgumentSpec.forFunctionReturning("combine", PythonDateTime.class)
-                        .addArgument("datetime_type", PythonLikeType.class)
-                        .addArgument("date", PythonDate.class)
-                        .addArgument("time", PythonTime.class)
-                        .addNullableArgument("tzinfo", PythonLikeObject.class)
+                ArgumentSpec.forFunctionReturning("combine", PythonDateTime.class.getName())
+                        .addArgument("datetime_type", PythonLikeType.class.getName())
+                        .addArgument("date", PythonDate.class.getName())
+                        .addArgument("time", PythonTime.class.getName())
+                        .addNullableArgument("tzinfo", PythonLikeObject.class.getName())
                         .asClassPythonFunctionSignature(
                                 PythonDateTime.class.getMethod("combine",
                                         PythonLikeType.class, PythonDate.class,
@@ -153,16 +153,16 @@ public class PythonDateTime extends PythonDate<PythonDateTime> implements Planni
 
         // Instance methods
         DATE_TIME_TYPE.addMethod("replace",
-                ArgumentSpec.forFunctionReturning("replace", PythonDate.class)
-                        .addNullableArgument("year", PythonInteger.class)
-                        .addNullableArgument("month", PythonInteger.class)
-                        .addNullableArgument("day", PythonInteger.class)
-                        .addNullableArgument("hour", PythonInteger.class)
-                        .addNullableArgument("minute", PythonInteger.class)
-                        .addNullableArgument("second", PythonInteger.class)
-                        .addNullableArgument("microsecond", PythonInteger.class)
-                        .addNullableArgument("tzinfo", PythonLikeObject.class)
-                        .addNullableKeywordOnlyArgument("fold", PythonInteger.class)
+                ArgumentSpec.forFunctionReturning("replace", PythonDate.class.getName())
+                        .addNullableArgument("year", PythonInteger.class.getName())
+                        .addNullableArgument("month", PythonInteger.class.getName())
+                        .addNullableArgument("day", PythonInteger.class.getName())
+                        .addNullableArgument("hour", PythonInteger.class.getName())
+                        .addNullableArgument("minute", PythonInteger.class.getName())
+                        .addNullableArgument("second", PythonInteger.class.getName())
+                        .addNullableArgument("microsecond", PythonInteger.class.getName())
+                        .addNullableArgument("tzinfo", PythonLikeObject.class.getName())
+                        .addNullableKeywordOnlyArgument("fold", PythonInteger.class.getName())
                         .asPythonFunctionSignature(PythonDateTime.class.getMethod("replace", PythonInteger.class,
                                 PythonInteger.class, PythonInteger.class,
                                 PythonInteger.class, PythonInteger.class, PythonInteger.class,
@@ -197,9 +197,9 @@ public class PythonDateTime extends PythonDate<PythonDateTime> implements Planni
                 PythonDateTime.class.getMethod("dst"));
 
         DATE_TIME_TYPE.addMethod("isoformat",
-                ArgumentSpec.forFunctionReturning("isoformat", PythonString.class)
-                        .addArgument("sep", PythonString.class, PythonString.valueOf("T"))
-                        .addArgument("timespec", PythonString.class, PythonString.valueOf("auto"))
+                ArgumentSpec.forFunctionReturning("isoformat", PythonString.class.getName())
+                        .addArgument("sep", PythonString.class.getName(), PythonString.valueOf("T"))
+                        .addArgument("timespec", PythonString.class.getName(), PythonString.valueOf("auto"))
                         .asPythonFunctionSignature(
                                 PythonDateTime.class.getMethod("iso_format", PythonString.class, PythonString.class)));
 

--- a/jpyinterpreter/src/main/java/ai/timefold/jpyinterpreter/types/datetime/PythonTime.java
+++ b/jpyinterpreter/src/main/java/ai/timefold/jpyinterpreter/types/datetime/PythonTime.java
@@ -55,39 +55,39 @@ public class PythonTime extends AbstractPythonLikeObject implements PlanningImmu
     }
 
     private static void registerMethods() throws NoSuchMethodException {
-        TIME_TYPE.addConstructor(ArgumentSpec.forFunctionReturning("datetime.time", PythonTime.class)
-                .addArgument("hour", PythonInteger.class, PythonInteger.ZERO)
-                .addArgument("minute", PythonInteger.class, PythonInteger.ZERO)
-                .addArgument("second", PythonInteger.class, PythonInteger.ZERO)
-                .addArgument("microsecond", PythonInteger.class, PythonInteger.ZERO)
-                .addArgument("tzinfo", PythonLikeObject.class, PythonNone.INSTANCE)
-                .addKeywordOnlyArgument("fold", PythonInteger.class, PythonInteger.ZERO)
+        TIME_TYPE.addConstructor(ArgumentSpec.forFunctionReturning("datetime.time", PythonTime.class.getName())
+                .addArgument("hour", PythonInteger.class.getName(), PythonInteger.ZERO)
+                .addArgument("minute", PythonInteger.class.getName(), PythonInteger.ZERO)
+                .addArgument("second", PythonInteger.class.getName(), PythonInteger.ZERO)
+                .addArgument("microsecond", PythonInteger.class.getName(), PythonInteger.ZERO)
+                .addArgument("tzinfo", PythonLikeObject.class.getName(), PythonNone.INSTANCE)
+                .addKeywordOnlyArgument("fold", PythonInteger.class.getName(), PythonInteger.ZERO)
                 .asPythonFunctionSignature(
                         PythonTime.class.getMethod("of", PythonInteger.class, PythonInteger.class,
                                 PythonInteger.class, PythonInteger.class, PythonLikeObject.class,
                                 PythonInteger.class)));
 
         TIME_TYPE.addMethod("fromisoformat",
-                ArgumentSpec.forFunctionReturning("fromisoformat", PythonTime.class)
-                        .addArgument("time_string", PythonString.class)
+                ArgumentSpec.forFunctionReturning("fromisoformat", PythonTime.class.getName())
+                        .addArgument("time_string", PythonString.class.getName())
                         .asStaticPythonFunctionSignature(PythonTime.class.getMethod("from_iso_format", PythonString.class)));
 
         TIME_TYPE.addMethod("replace",
-                ArgumentSpec.forFunctionReturning("replace", PythonTime.class)
-                        .addNullableArgument("hour", PythonInteger.class)
-                        .addNullableArgument("minute", PythonInteger.class)
-                        .addNullableArgument("second", PythonInteger.class)
-                        .addNullableArgument("microsecond", PythonInteger.class)
-                        .addNullableArgument("tzinfo", PythonLikeObject.class)
-                        .addNullableKeywordOnlyArgument("fold", PythonInteger.class)
+                ArgumentSpec.forFunctionReturning("replace", PythonTime.class.getName())
+                        .addNullableArgument("hour", PythonInteger.class.getName())
+                        .addNullableArgument("minute", PythonInteger.class.getName())
+                        .addNullableArgument("second", PythonInteger.class.getName())
+                        .addNullableArgument("microsecond", PythonInteger.class.getName())
+                        .addNullableArgument("tzinfo", PythonLikeObject.class.getName())
+                        .addNullableKeywordOnlyArgument("fold", PythonInteger.class.getName())
                         .asPythonFunctionSignature(PythonTime.class.getMethod("replace", PythonInteger.class,
                                 PythonInteger.class, PythonInteger.class,
                                 PythonInteger.class, PythonLikeObject.class,
                                 PythonInteger.class)));
 
         TIME_TYPE.addMethod("isoformat",
-                ArgumentSpec.forFunctionReturning("isoformat", PythonString.class)
-                        .addArgument("timespec", PythonString.class, PythonString.valueOf("auto"))
+                ArgumentSpec.forFunctionReturning("isoformat", PythonString.class.getName())
+                        .addArgument("timespec", PythonString.class.getName(), PythonString.valueOf("auto"))
                         .asPythonFunctionSignature(PythonTime.class.getMethod("isoformat", PythonString.class)));
 
         TIME_TYPE.addMethod("tzname",

--- a/jpyinterpreter/src/main/java/ai/timefold/jpyinterpreter/types/datetime/PythonTimeDelta.java
+++ b/jpyinterpreter/src/main/java/ai/timefold/jpyinterpreter/types/datetime/PythonTimeDelta.java
@@ -53,14 +53,14 @@ public class PythonTimeDelta extends AbstractPythonLikeObject implements PythonL
 
     private static void registerMethods() throws NoSuchMethodException {
         // Constructor
-        TIME_DELTA_TYPE.addConstructor(ArgumentSpec.forFunctionReturning("timedelta", PythonTimeDelta.class)
-                .addArgument("days", PythonNumber.class, PythonInteger.ZERO)
-                .addArgument("seconds", PythonNumber.class, PythonInteger.ZERO)
-                .addArgument("microseconds", PythonNumber.class, PythonInteger.ZERO)
-                .addArgument("milliseconds", PythonNumber.class, PythonInteger.ZERO)
-                .addArgument("minutes", PythonNumber.class, PythonInteger.ZERO)
-                .addArgument("hours", PythonNumber.class, PythonInteger.ZERO)
-                .addArgument("weeks", PythonNumber.class, PythonInteger.ZERO)
+        TIME_DELTA_TYPE.addConstructor(ArgumentSpec.forFunctionReturning("timedelta", PythonTimeDelta.class.getName())
+                .addArgument("days", PythonNumber.class.getName(), PythonInteger.ZERO)
+                .addArgument("seconds", PythonNumber.class.getName(), PythonInteger.ZERO)
+                .addArgument("microseconds", PythonNumber.class.getName(), PythonInteger.ZERO)
+                .addArgument("milliseconds", PythonNumber.class.getName(), PythonInteger.ZERO)
+                .addArgument("minutes", PythonNumber.class.getName(), PythonInteger.ZERO)
+                .addArgument("hours", PythonNumber.class.getName(), PythonInteger.ZERO)
+                .addArgument("weeks", PythonNumber.class.getName(), PythonInteger.ZERO)
                 .asPythonFunctionSignature(PythonTimeDelta.class.getMethod("of", PythonNumber.class, PythonNumber.class,
                         PythonNumber.class, PythonNumber.class, PythonNumber.class, PythonNumber.class, PythonNumber.class)));
 

--- a/jpyinterpreter/src/main/python/__init__.py
+++ b/jpyinterpreter/src/main/python/__init__.py
@@ -2,7 +2,7 @@
 This module acts as an interface to the Python bytecode to Java bytecode interpreter
 """
 from .jvm_setup import init, set_class_output_directory
-from .annotations import JavaAnnotation, add_class_annotation, add_java_interface
+from .annotations import JavaAnnotation, AnnotationValueSupplier, add_class_annotation, add_java_interface
 from .conversions import (convert_to_java_python_like_object, unwrap_python_like_object,
                           update_python_object_from_java, is_c_native)
 from .translator import (translate_python_bytecode_to_java_bytecode,

--- a/jpyinterpreter/src/test/java/ai/timefold/jpyinterpreter/util/arguments/ArgumentSpecTest.java
+++ b/jpyinterpreter/src/test/java/ai/timefold/jpyinterpreter/util/arguments/ArgumentSpecTest.java
@@ -21,7 +21,7 @@ import org.junit.jupiter.api.Test;
 public class ArgumentSpecTest {
     @Test
     public void testSpec() {
-        ArgumentSpec<?> current = ArgumentSpec.forFunctionReturning("myFunction", PythonLikeTuple.class);
+        ArgumentSpec<?> current = ArgumentSpec.forFunctionReturning("myFunction", PythonLikeTuple.class.getName());
 
         List<String> argumentNameList = new ArrayList<>();
         List<PythonInteger> argumentValueList = new ArrayList<>();
@@ -39,7 +39,7 @@ public class ArgumentSpecTest {
                 assertThat(out).containsExactlyElementsOf(argumentValueList);
             }
 
-            current = current.addArgument("arg" + i, PythonInteger.class);
+            current = current.addArgument("arg" + i, PythonInteger.class.getName());
             argumentNameList.add("arg" + i);
             argumentValueList.add(PythonInteger.valueOf(i));
         }
@@ -47,7 +47,7 @@ public class ArgumentSpecTest {
 
     @Test
     public void testSpecWithDefaults() {
-        ArgumentSpec<?> current = ArgumentSpec.forFunctionReturning("myFunction", PythonLikeTuple.class);
+        ArgumentSpec<?> current = ArgumentSpec.forFunctionReturning("myFunction", PythonLikeTuple.class.getName());
 
         List<String> argumentNameList = new ArrayList<>();
         List<PythonInteger> argumentValueList = new ArrayList<>();
@@ -73,7 +73,7 @@ public class ArgumentSpecTest {
                 }
             }
 
-            current = current.addArgument("arg" + i, PythonInteger.class, PythonInteger.valueOf(-i));
+            current = current.addArgument("arg" + i, PythonInteger.class.getName(), PythonInteger.valueOf(-i));
             argumentNameList.add("arg" + i);
             argumentValueList.add(PythonInteger.valueOf(i));
         }
@@ -81,8 +81,8 @@ public class ArgumentSpecTest {
 
     @Test
     public void testSpecMissingArgument() {
-        ArgumentSpec<?> current = ArgumentSpec.forFunctionReturning("myFunction", PythonLikeTuple.class)
-                .addArgument("_arg0", PythonInteger.class);
+        ArgumentSpec<?> current = ArgumentSpec.forFunctionReturning("myFunction", PythonLikeTuple.class.getName())
+                .addArgument("_arg0", PythonInteger.class.getName());
 
         List<String> argumentNameList = new ArrayList<>();
         List<PythonInteger> argumentValueList = new ArrayList<>();
@@ -105,7 +105,7 @@ public class ArgumentSpecTest {
                         .hasMessageContaining("myFunction() missing 1 required positional argument: '");
             }
 
-            current = current.addArgument("arg" + i, PythonInteger.class);
+            current = current.addArgument("arg" + i, PythonInteger.class.getName());
             argumentNameList.add("arg" + i);
             argumentValueList.add(PythonInteger.valueOf(i));
         }
@@ -113,7 +113,7 @@ public class ArgumentSpecTest {
 
     @Test
     public void testSpecExtraArgument() {
-        ArgumentSpec<?> current = ArgumentSpec.forFunctionReturning("myFunction", PythonLikeTuple.class);
+        ArgumentSpec<?> current = ArgumentSpec.forFunctionReturning("myFunction", PythonLikeTuple.class.getName());
 
         List<String> argumentNameList = new ArrayList<>();
         List<PythonInteger> argumentValueList = new ArrayList<>();
@@ -147,7 +147,7 @@ public class ArgumentSpecTest {
                         .containsAnyOf(possibleErrorMessages);
             }
 
-            current = current.addArgument("arg" + i, PythonInteger.class);
+            current = current.addArgument("arg" + i, PythonInteger.class.getName());
             argumentNameList.add("arg" + i);
             argumentValueList.add(PythonInteger.valueOf(i));
         }

--- a/jpyinterpreter/tests/test_classes.py
+++ b/jpyinterpreter/tests/test_classes.py
@@ -964,6 +964,28 @@ def test_generic_field_type():
     assert field_type.getActualTypeArguments()[0].getName() == PythonString.class_.getName()
 
 
+def test_getter_type():
+    from typing import Optional, Union
+    from ai.timefold.jpyinterpreter.types import PythonString, PythonBytes
+    from ai.timefold.jpyinterpreter.types.numeric import PythonInteger
+    from jpyinterpreter import translate_python_class_to_java_class
+
+    class A:
+        str_field: Optional[str]
+        int_field: Union[int, None]
+        bytes_field: bytes | None
+
+    translated_class = translate_python_class_to_java_class(A).getJavaClass()
+    str_field_getter_type = translated_class.getMethod('getStr_field').getReturnType()
+    assert str_field_getter_type == PythonString.class_
+
+    int_field_getter_type = translated_class.getMethod('getInt_field').getReturnType()
+    assert int_field_getter_type == PythonInteger.class_
+
+    bytes_field_getter_type = translated_class.getMethod('getBytes_field').getReturnType()
+    assert bytes_field_getter_type == PythonBytes.class_
+
+
 def test_marker_interface():
     from ai.timefold.jpyinterpreter.types.wrappers import OpaquePythonReference
     from jpyinterpreter import translate_python_class_to_java_class, add_java_interface

--- a/tests/test_vehicle_routing.py
+++ b/tests/test_vehicle_routing.py
@@ -1,0 +1,306 @@
+from datetime import datetime, timedelta
+
+from timefold.solver.api import *
+from timefold.solver.annotation import *
+from timefold.solver.config import *
+from timefold.solver.constraint import ConstraintFactory
+from timefold.solver.score import *
+
+from typing import Annotated, List, Optional
+from dataclasses import dataclass, field
+
+
+@dataclass
+class Location:
+    latitude: float
+    longitude: float
+    driving_time_seconds: dict[int, int] = field(default_factory=dict)
+
+    def driving_time_to(self, other: 'Location') -> int:
+        return self.driving_time_seconds[id(other)]
+
+
+class ArrivalTimeUpdatingVariableListener(VariableListener):
+    def after_variable_changed(self, score_director: ScoreDirector, visit: 'Visit') -> None:
+        if visit.vehicle is None:
+            if visit.arrival_time is not None:
+                score_director.before_variable_changed(visit, 'arrival_time')
+                visit.arrival_time = None
+                score_director.after_variable_changed(visit, 'arrival_time')
+            return
+        previous_visit = visit.previous_visit
+        departure_time = visit.vehicle.departure_time if previous_visit is None else previous_visit.departure_time()
+        next_visit = visit
+        arrival_time = ArrivalTimeUpdatingVariableListener.calculate_arrival_time(next_visit, departure_time)
+        while next_visit is not None and next_visit.arrival_time != arrival_time:
+            score_director.before_variable_changed(next_visit, 'arrival_time')
+            next_visit.arrival_time = arrival_time
+            score_director.after_variable_changed(next_visit, 'arrival_time')
+            departure_time = next_visit.departure_time()
+            next_visit = next_visit.next_visit
+            arrival_time = ArrivalTimeUpdatingVariableListener.calculate_arrival_time(next_visit, departure_time)
+
+    @staticmethod
+    def calculate_arrival_time(visit: Optional['Visit'], previous_departure_time: Optional[datetime]) \
+            -> datetime | None:
+        if visit is None or previous_departure_time is None:
+            return None
+        return previous_departure_time + timedelta(seconds=visit.driving_time_seconds_from_previous_standstill())
+
+
+@planning_entity
+@dataclass
+class Visit:
+    id: Annotated[str, PlanningId]
+    name: str
+    location: Location
+    demand: int
+    min_start_time: datetime
+    max_end_time: datetime
+    service_duration: timedelta
+    vehicle: Annotated[Optional['Vehicle'], InverseRelationShadowVariable(source_variable_name='visits')] = (
+        field(default=None))
+    previous_visit: Annotated[Optional['Visit'], PreviousElementShadowVariable(source_variable_name='visits')] = (
+        field(default=None))
+    next_visit: Annotated[Optional['Visit'],
+                          NextElementShadowVariable(source_variable_name='visits')] = field(default=None)
+    arrival_time: Annotated[Optional[datetime],
+                            ShadowVariable(variable_listener_class=ArrivalTimeUpdatingVariableListener,
+                                           source_variable_name='vehicle'),
+                            ShadowVariable(variable_listener_class=ArrivalTimeUpdatingVariableListener,
+                                           source_variable_name='previous_visit')] = field(default=None)
+
+    def departure_time(self) -> Optional[datetime]:
+        if self.arrival_time is None:
+            return None
+
+        return self.arrival_time + self.service_duration
+
+    def start_service_time(self) -> Optional[datetime]:
+        if self.arrival_time is None:
+            return None
+        return self.min_start_time if (self.min_start_time < self.arrival_time) else self.arrival_time
+
+    def is_service_finished_after_max_end_time(self) -> bool:
+        return self.arrival_time is not None and self.departure_time() > self.max_end_time
+
+    def service_finished_delay_in_minutes(self) -> int:
+        if self.arrival_time is None:
+            return 0
+        return (self.max_end_time - self.departure_time()).seconds // 60
+
+    def driving_time_seconds_from_previous_standstill(self) -> int:
+        if self.vehicle is None:
+            raise ValueError("This method must not be called when the shadow variables are not initialized yet.")
+
+        if self.previous_visit is None:
+            return self.vehicle.home_location.driving_time_to(self.location)
+        else:
+            return self.previous_visit.location.driving_time_to(self.location)
+
+    def driving_time_seconds_from_previous_standstill_or_none(self) -> Optional[int]:
+        if self.vehicle is None:
+            return None
+        return self.driving_time_seconds_from_previous_standstill()
+
+    def __str__(self):
+        return self.id
+
+
+@planning_entity
+@dataclass
+class Vehicle:
+    id: Annotated[str, PlanningId]
+    capacity: int
+    home_location: Location
+    departure_time: datetime
+    visits: Annotated[list[Visit], PlanningListVariable] = field(default_factory=list)
+
+    def total_demand(self) -> int:
+        total_demand = 0
+        for visit in self.visits:
+            total_demand += visit.demand
+        return total_demand
+
+    def total_driving_time_seconds(self) -> int:
+        if len(self.visits) == 0:
+            return 0
+        total_driving_time_seconds = 0
+        previous_location = self.home_location
+
+        for visit in self.visits:
+            total_driving_time_seconds += previous_location.driving_time_to(visit.location)
+            previous_location = visit.location
+
+        total_driving_time_seconds += previous_location.driving_time_to(self.home_location)
+        return total_driving_time_seconds
+
+    def arrival_time(self):
+        if len(self.visits) == 0:
+            return self.departure_time
+
+        last_visit = self.visits[-1]
+        return (last_visit.departure_time() +
+                timedelta(seconds=last_visit.location.driving_time_to(self.home_location)))
+
+
+@planning_solution
+@dataclass
+class VehicleRoutePlan:
+    vehicles: Annotated[list[Vehicle], PlanningEntityCollectionProperty]
+    visits: Annotated[list[Visit], PlanningEntityCollectionProperty, ValueRangeProvider]
+    score: Annotated[HardSoftScore, PlanningScore] = field(default=None)
+
+
+@constraint_provider
+def vehicle_routing_constraints(factory: ConstraintFactory):
+    return [
+        vehicle_capacity(factory),
+        service_finished_after_max_end_time(factory),
+        minimize_travel_time(factory)
+    ]
+
+##############################################
+# Hard constraints
+##############################################
+
+
+def vehicle_capacity(factory: ConstraintFactory):
+    return (factory.for_each(Vehicle)
+            .filter(lambda vehicle: vehicle.total_demand() > vehicle.capacity)
+            .penalize(HardSoftScore.ONE_HARD,
+                      lambda vehicle: vehicle.total_demand() - vehicle.capacity)
+            .as_constraint('VEHICLE_CAPACITY')
+            )
+
+
+def service_finished_after_max_end_time(factory: ConstraintFactory):
+    return (factory.for_each(Visit)
+            .filter(lambda visit: visit.is_service_finished_after_max_end_time())
+            .penalize(HardSoftScore.ONE_HARD,
+                      lambda visit: visit.service_finished_delay_in_minutes())
+            .as_constraint('SERVICE_FINISHED_AFTER_MAX_END_TIME')
+            )
+
+##############################################
+# Soft constraints
+##############################################
+
+
+def minimize_travel_time(factory: ConstraintFactory):
+    return (
+        factory.for_each(Vehicle)
+        .penalize(HardSoftScore.ONE_SOFT,
+                  lambda vehicle: vehicle.total_driving_time_seconds())
+        .as_constraint('MINIMIZE_TRAVEL_TIME')
+    )
+
+
+def test_vrp():
+    solver_config = SolverConfig(
+        solution_class=VehicleRoutePlan,
+        entity_class_list=[Vehicle, Visit],
+        score_director_factory_config=ScoreDirectorFactoryConfig(
+            constraint_provider_function=vehicle_routing_constraints
+        ),
+        termination_config=TerminationConfig(
+            best_score_limit='0hard/-300soft'
+        )
+    )
+
+    solver = SolverFactory.create(solver_config).build_solver()
+    l1 = Location(1, 1)
+    l2 = Location(2, 2)
+    l3 = Location(3, 3)
+    l4 = Location(4, 4)
+    l5 = Location(5, 5)
+
+    l1.driving_time_seconds = {
+        id(l1): 0,
+        id(l2): 60,
+        id(l3): 60 * 60,
+        id(l4): 60 * 60,
+        id(l5): 60 * 60
+    }
+
+    l2.driving_time_seconds = {
+        id(l1): 60 * 60,
+        id(l2): 0,
+        id(l3): 60,
+        id(l4): 60 * 60,
+        id(l5): 60 * 60
+    }
+
+    l3.driving_time_seconds = {
+        id(l1): 60,
+        id(l2): 60 * 60,
+        id(l3): 0,
+        id(l4): 60 * 60,
+        id(l5): 60 * 60
+    }
+
+    l4.driving_time_seconds = {
+        id(l1): 60 * 60,
+        id(l2): 60 * 60,
+        id(l3): 60 * 60,
+        id(l4): 0,
+        id(l5): 60
+    }
+
+    l5.driving_time_seconds = {
+        id(l1): 60 * 60,
+        id(l2): 60 * 60,
+        id(l3): 60 * 60,
+        id(l4): 60,
+        id(l5): 0
+    }
+
+    problem = VehicleRoutePlan(
+        vehicles=[
+            Vehicle(
+                id='A',
+                capacity=3,
+                home_location=l1,
+                departure_time=datetime(2020, 1, 1),
+            ),
+            Vehicle(
+                id='B',
+                capacity=3,
+                home_location=l4,
+                departure_time=datetime(2020, 1, 1),
+            ),
+        ],
+        visits=[
+            Visit(
+                id='1',
+                name='1',
+                location=l2,
+                demand=1,
+                min_start_time=datetime(2020, 1, 1),
+                max_end_time=datetime(2020, 1, 1, hour=10),
+                service_duration=timedelta(hours=1),
+            ),
+            Visit(
+                id='2',
+                name='2',
+                location=l3,
+                demand=1,
+                min_start_time=datetime(2020, 1, 1),
+                max_end_time=datetime(2020, 1, 1, hour=10),
+                service_duration=timedelta(hours=1),
+            ),
+            Visit(
+                id='3',
+                name='3',
+                location=l5,
+                demand=1,
+                min_start_time=datetime(2020, 1, 1),
+                max_end_time=datetime(2020, 1, 1, hour=10),
+                service_duration=timedelta(hours=1),
+            ),
+        ]
+    )
+    solution = solver.solve(problem)
+
+    assert [visit.id for visit in solution.vehicles[0].visits] == ['1', '2']
+    assert [visit.id for visit in solution.vehicles[1].visits] == ['3']

--- a/timefold-solver-python-core/src/main/python/api/_solver_manager.py
+++ b/timefold-solver-python-core/src/main/python/api/_solver_manager.py
@@ -6,7 +6,7 @@ from ._future import wrap_completable_future
 from asyncio import Future
 from typing import TypeVar, Generic, Callable, TYPE_CHECKING
 from datetime import timedelta
-from enum import Enum, auto as auto_enum
+from enum import Enum
 
 if TYPE_CHECKING:
     # These imports require a JVM to be running, so only import if type checking
@@ -19,9 +19,9 @@ ProblemId_ = TypeVar('ProblemId_')
 
 
 class SolverStatus(Enum):
-    NOT_SOLVING = auto_enum()
-    SOLVING_SCHEDULED = auto_enum()
-    SOLVING_ACTIVE = auto_enum()
+    NOT_SOLVING = 'NOT_SOLVING'
+    SOLVING_SCHEDULED = 'SOLVING_SCHEDULED'
+    SOLVING_ACTIVE = 'SOLVING_ACTIVE'
 
     @staticmethod
     def _from_java_enum(enum_value):

--- a/timefold-solver-python-core/src/main/python/config/_config.py
+++ b/timefold-solver-python-core/src/main/python/config/_config.py
@@ -3,7 +3,7 @@ from .._timefold_java_interop import is_enterprise_installed
 
 from typing import Any, Optional, List, Type, Callable, TypeVar, Generic, TYPE_CHECKING
 from dataclasses import dataclass, field
-from enum import Enum, auto
+from enum import Enum
 from pathlib import Path
 from jpype import JClass
 
@@ -65,28 +65,28 @@ class Duration:
 
 
 class EnvironmentMode(Enum):
-    NON_REPRODUCIBLE = auto()
-    REPRODUCIBLE = auto()
-    FAST_ASSERT = auto()
-    NON_INTRUSIVE_FULL_ASSERT = auto()
-    FULL_ASSERT = auto()
-    TRACKED_FULL_ASSERT = auto()
+    NON_REPRODUCIBLE = 'NON_REPRODUCIBLE'
+    REPRODUCIBLE = 'REPRODUCIBLE'
+    FAST_ASSERT = 'FAST_ASSERT'
+    NON_INTRUSIVE_FULL_ASSERT = 'NON_INTRUSIVE_FULL_ASSERT'
+    FULL_ASSERT = 'FULL_ASSERT'
+    TRACKED_FULL_ASSERT = 'TRACKED_FULL_ASSERT'
 
     def _get_java_enum(self):
         return _lookup_on_java_class(_java_environment_mode, self.name)
 
 
 class TerminationCompositionStyle(Enum):
-    OR = auto()
-    AND = auto()
+    OR = 'OR'
+    AND = 'AND'
 
     def _get_java_enum(self):
         return _lookup_on_java_class(_java_termination_composition_style, self.name)
 
 
 class MoveThreadCount(Enum):
-    AUTO = auto()
-    NONE = auto()
+    AUTO = 'AUTO'
+    NONE = 'NONE'
 
 
 class RequiresEnterpriseError(EnvironmentError):
@@ -122,11 +122,14 @@ class SolverConfig(Generic[Solution_]):
         return SolverConfig(xml_source_text=xml_text)
 
     def _to_java_solver_config(self) -> '_JavaSolverConfig':
-        from .._timefold_java_interop import OverrideClassLoader, get_class
+        from .._timefold_java_interop import OverrideClassLoader, get_class, _process_compilation_queue
         from ai.timefold.solver.core.config.solver import SolverConfig as JavaSolverConfig
         from java.io import File, ByteArrayInputStream  # noqa
         from java.lang import IllegalArgumentException
         from java.util import ArrayList
+
+        _process_compilation_queue()
+
         out = JavaSolverConfig()
         with OverrideClassLoader() as class_loader:
             out.setClassLoader(class_loader)


### PR DESCRIPTION
- Previously, we eagerly compile the class as soon as `@planning_entity` or `@planning_solution` is reached. This cause problem if the class contains forward references, since:

  - The referenced class does not exist when `@planning_entity` or `@planning_solution` is reached, since it is defined later.

  - This causes `get_type_hints` to raise a NameError, since it cannot find the type name in locals or globals

  Now, the classes are compiled when the SolverConfig is read (and
  thus, all the referenced classes should be defined).

- In order to handle forward references in annotations and the class translator, usage of getJavaClass (which may throw an exception if the class is in the middle of being defined)  need to be changed to getJavaClassInternalName (which will never throw). Thus:

  - ArgumentSpec now take the return type and parameters of a function as String instead of their Class. There could be a Class overload that calls the String version, but I decided against it to prevent the temptation to pass getJavaClass to it.

  - PythonDefaultArgumentImplementor now sets its constants inside <clinit>, which means ArgumentSpec must store itself in a static field so clinit can access it. This is because if a Class cannot be loaded until all the Classes it references are defined (and thus, we cannot set the field values from Java, since PythonDefaultArgumentImplementor might reference a class still being defined).

  - AnnotationMetadata now store Class values as Type instead of Class.

- In order for Timefold to discover the "true" type of annotated getters, we remove NoneType from the Union of the getter return type (but keep it in the actual field type). That is, if a type is annotated `Value | None`, the getter type will be `Value`, and the field type will be `get_common_ancestor(Value, NoneType) = object`.

- Use PythonClassWriter instead of ClassWriter in the ClassTranslator, so ASM will not complain about missing classes when computing frames.

- In order to properly visit a repeatable annotation, we need to group the repeated annotation by type and put them as the value of their container annotation class.

- Make VersionMapping throw an exception if it gets a null version mapping (otherwise, an undescriptive NPE will happen if the unsupported opcode is in the bytecode).

- Added the missing PreviousElementShadowVariable and NextElementShadowVariable annotations.

- Use str enums, so the enum serializes to their names instead of a number.