### PR TITLE
ci: optimize update parent in change_versions.sh

### DIFF
--- a/.github/scripts/change_versions.sh
+++ b/.github/scripts/change_versions.sh
@@ -11,7 +11,7 @@
 echo "     New version: $NEW_VERSION"
 echo "     New Python Version: $NEW_VERSION_PYTHON"
 mvn clean install -Dquickly
-mvn versions:update-parent "-DparentVersion=[$NEW_VERSION,$NEW_VERSION]" -DallowSnapshots=true -DgenerateBackupPoms=false
+mvn versions:update-parent "-DparentVersion=$NEW_VERSION" -DskipResolution=true -DallowSnapshots=true -DgenerateBackupPoms=false
 mvn versions:update-child-modules -DallowSnapshots=true -DgenerateBackupPoms=false
 sed -i "s/^timefold_solver_python_version.*=.*/timefold_solver_python_version = '$NEW_VERSION_PYTHON'/" setup.py
 git commit -am "build: switch to version $NEW_VERSION_PYTHON"


### PR DESCRIPTION
`-DskipResolution=true` tells `versions:update-parent` to skip looking up the parent version and allows us to set the version directly (https://www.mojohaus.org/versions/versions-maven-plugin/update-parent-mojo.html#skipResolution).