### PR TITLE
fix: Load globals that are subclasses or instances of a class being compiled lazily

### DIFF
--- a/jpyinterpreter/src/main/java/ai/timefold/jpyinterpreter/util/PythonGlobalsBackedMap.java
+++ b/jpyinterpreter/src/main/java/ai/timefold/jpyinterpreter/util/PythonGlobalsBackedMap.java
@@ -1,0 +1,17 @@
+package ai.timefold.jpyinterpreter.util;
+
+import java.util.HashMap;
+
+import ai.timefold.jpyinterpreter.PythonLikeObject;
+
+public class PythonGlobalsBackedMap extends HashMap<String, PythonLikeObject> {
+    private final long pythonGlobalsId;
+
+    public PythonGlobalsBackedMap(long pythonGlobalsId) {
+        this.pythonGlobalsId = pythonGlobalsId;
+    }
+
+    public long getPythonGlobalsId() {
+        return pythonGlobalsId;
+    }
+}

--- a/jpyinterpreter/tests/test_classes.py
+++ b/jpyinterpreter/tests/test_classes.py
@@ -896,6 +896,20 @@ def test_class_vargs_with_manatory_args():
     verifier.verify(1, 1, 1, expected_result=13)
 
 
+def test_enum_translate_to_class():
+    from enum import Enum
+    from jpyinterpreter import translate_python_class_to_java_class
+    from ai.timefold.jpyinterpreter.types.wrappers import CPythonType
+
+    class Color(Enum):
+        RED = 'RED'
+        GREEN = 'GREEN'
+        BLUE = 'BLUE'
+
+    translated_class = translate_python_class_to_java_class(Color)
+    assert not isinstance(translated_class, CPythonType)
+
+
 def test_class_annotations():
     from typing import Annotated
     from java.lang import Deprecated


### PR DESCRIPTION
Previously, the entire global dict was loaded whenever a function was compiled. However, this causes issues if there is a global that is an instance or subclass of a class being compiled, and the class being compiled reference that global.

Now, when a class is being compiled, instances and subclasses of that class is excluded and loaded at runtime.