### PR TITLE
chore: remove usage of importlib.resources.path as it deprecated

### DIFF
--- a/jpyinterpreter/src/main/python/__init__.py
+++ b/jpyinterpreter/src/main/python/__init__.py
@@ -1,7 +1,7 @@
 """
 This module acts as an interface to the Python bytecode to Java bytecode interpreter
 """
-from .jvm_setup import init, set_class_output_directory
+from .jvm_setup import init, set_class_output_directory, get_path
 from .annotations import JavaAnnotation, AnnotationValueSupplier, add_class_annotation, add_java_interface
 from .conversions import (convert_to_java_python_like_object, unwrap_python_like_object,
                           update_python_object_from_java, is_c_native, add_python_java_type_mapping)

--- a/timefold-solver-python-core/src/main/python/_timefold_java_interop.py
+++ b/timefold-solver-python-core/src/main/python/_timefold_java_interop.py
@@ -5,6 +5,7 @@ import jpype.imports
 from jpype.types import *
 import importlib.resources
 from typing import cast, TypeVar, Callable, Union, TYPE_CHECKING, Any
+from _jpyinterpreter import get_path
 from ._jpype_type_conversions import PythonSupplier, ConstraintProviderFunction, PythonConsumer
 
 if TYPE_CHECKING:
@@ -43,15 +44,15 @@ def extract_timefold_jars() -> list[str]:
     global _enterprise_installed
     try:
 
-        enterprise_dependencies = [str(importlib.resources.path('timefold.solver.enterprise.jars',
-                                                                p.name).__enter__())
+        enterprise_dependencies = [str(get_path('timefold.solver.enterprise.jars',
+                                                p.name).__enter__())
                                    for p in importlib.resources.files('timefold.solver.enterprise.jars').iterdir()
                                    if p.name.endswith(".jar")]
         _enterprise_installed = True
     except ModuleNotFoundError:
         enterprise_dependencies = []
         _enterprise_installed = False
-    return [str(importlib.resources.path('timefold.solver.jars', p.name).__enter__())
+    return [str(get_path('timefold.solver.jars', p.name).__enter__())
             for p in importlib.resources.files('timefold.solver.jars').iterdir()
             if p.name.endswith(".jar")] + enterprise_dependencies
 


### PR DESCRIPTION
Used the official migration receipe at
https://importlib-resources.readthedocs.io/en/latest/using.html#migrating-from-legacy