### PR TITLE
fix: Use Number.doubleValue() instead of float(Number) for conversions

### DIFF
--- a/jpyinterpreter/src/main/python/conversions.py
+++ b/jpyinterpreter/src/main/python/conversions.py
@@ -538,7 +538,7 @@ def unwrap_python_like_object(python_like_object, clone_map=None, default=NotImp
     elif isinstance(python_like_object, JavaNotImplemented):
         return clone_map.add_clone(python_like_object, NotImplemented)
     elif isinstance(python_like_object, PythonFloat):
-        return clone_map.add_clone(python_like_object, float(python_like_object.getValue()))
+        return clone_map.add_clone(python_like_object, python_like_object.getValue().doubleValue())
     elif isinstance(python_like_object, PythonString):
         return clone_map.add_clone(python_like_object, python_like_object.getValue())
     elif isinstance(python_like_object, PythonBytes):


### PR DESCRIPTION
When testing VRP, it was discovered that occasionally, the location, represented as a pair of floats, was converted incorrectly.

It appears JPype's float conversion for Number is inconsistent, so we use Number.doubleValue() instead, which seems to consistency convert correctly.

Ideally, `test_float.test_use_64_bits` or the other float tests would have catch it, but somehow, those tests never failed; the exact condition for incorrect conversion is unknown.