### PR TITLE
fix: Case handling in byte and bytearray methods, converting unicode to ascii array

### DIFF
--- a/jpyinterpreter/src/main/java/ai/timefold/jpyinterpreter/types/PythonByteArray.java
+++ b/jpyinterpreter/src/main/java/ai/timefold/jpyinterpreter/types/PythonByteArray.java
@@ -1909,10 +1909,7 @@ public class PythonByteArray extends AbstractPythonLikeObject implements PythonB
                     if (cp >= 128) {
                         return cp;
                     }
-                    if (Character.isLowerCase(cp)) {
-                        return Character.toUpperCase(cp);
-                    }
-                    return Character.toLowerCase(cp);
+                    return PythonString.CharacterCase.swapCase(cp);
                 }
         ).asAsciiByteArray();
     }

--- a/jpyinterpreter/src/main/java/ai/timefold/jpyinterpreter/types/PythonByteArray.java
+++ b/jpyinterpreter/src/main/java/ai/timefold/jpyinterpreter/types/PythonByteArray.java
@@ -339,7 +339,8 @@ public class PythonByteArray extends AbstractPythonLikeObject implements PythonB
     }
 
     public final PythonLikeTuple asIntTuple() {
-        return IntStream.range(0, valueBuffer.limit()).mapToObj(index -> PythonBytes.BYTE_TO_INT[Byte.toUnsignedInt(valueBuffer.get(index))])
+        return IntStream.range(0, valueBuffer.limit())
+                .mapToObj(index -> PythonBytes.BYTE_TO_INT[Byte.toUnsignedInt(valueBuffer.get(index))])
                 .collect(Collectors.toCollection(PythonLikeTuple::new));
     }
 
@@ -1829,7 +1830,7 @@ public class PythonByteArray extends AbstractPythonLikeObject implements PythonB
             return asString.asAsciiByteArray();
         }
         var tail = PythonString.valueOf(asString.value.substring(1))
-                .withModifiedCodepoints(cp -> cp < 128? Character.toLowerCase(cp) : cp).value;
+                .withModifiedCodepoints(cp -> cp < 128 ? Character.toLowerCase(cp) : cp).value;
         var head = asString.value.charAt(0);
         if (head < 128) {
             head = Character.toTitleCase(head);
@@ -1885,8 +1886,7 @@ public class PythonByteArray extends AbstractPythonLikeObject implements PythonB
 
     public PythonByteArray lower() {
         return asAsciiString().withModifiedCodepoints(
-                cp -> cp < 128? Character.toLowerCase(cp) : cp
-        ).asAsciiByteArray();
+                cp -> cp < 128 ? Character.toLowerCase(cp) : cp).asAsciiByteArray();
     }
 
     public PythonLikeList<PythonByteArray> splitLines() {
@@ -1905,13 +1905,7 @@ public class PythonByteArray extends AbstractPythonLikeObject implements PythonB
 
     public PythonByteArray swapCase() {
         return asAsciiString().withModifiedCodepoints(
-                cp -> {
-                    if (cp >= 128) {
-                        return cp;
-                    }
-                    return PythonString.CharacterCase.swapCase(cp);
-                }
-        ).asAsciiByteArray();
+                cp -> cp < 128 ? PythonString.CharacterCase.swapCase(cp) : cp).asAsciiByteArray();
     }
 
     public PythonByteArray title() {
@@ -1920,8 +1914,7 @@ public class PythonByteArray extends AbstractPythonLikeObject implements PythonB
 
     public PythonByteArray upper() {
         return asAsciiString().withModifiedCodepoints(
-                cp -> cp < 128? Character.toUpperCase(cp) : cp
-        ).asAsciiByteArray();
+                cp -> cp < 128 ? Character.toUpperCase(cp) : cp).asAsciiByteArray();
     }
 
     public PythonByteArray zfill(PythonInteger width) {

--- a/jpyinterpreter/src/main/java/ai/timefold/jpyinterpreter/types/PythonBytes.java
+++ b/jpyinterpreter/src/main/java/ai/timefold/jpyinterpreter/types/PythonBytes.java
@@ -1602,7 +1602,7 @@ public class PythonBytes extends AbstractPythonLikeObject implements PythonBytes
             return this;
         }
         var tail = PythonString.valueOf(asString.value.substring(1))
-                .withModifiedCodepoints(cp -> cp < 128? Character.toLowerCase(cp) : cp).value;
+                .withModifiedCodepoints(cp -> cp < 128 ? Character.toLowerCase(cp) : cp).value;
         var head = asString.value.charAt(0);
         if (head < 128) {
             head = Character.toTitleCase(head);
@@ -1657,8 +1657,7 @@ public class PythonBytes extends AbstractPythonLikeObject implements PythonBytes
 
     public PythonBytes lower() {
         return asAsciiString().withModifiedCodepoints(
-                cp -> cp < 128? Character.toLowerCase(cp) : cp
-        ).asAsciiBytes();
+                cp -> cp < 128 ? Character.toLowerCase(cp) : cp).asAsciiBytes();
     }
 
     public PythonLikeList<PythonBytes> splitLines() {
@@ -1677,13 +1676,7 @@ public class PythonBytes extends AbstractPythonLikeObject implements PythonBytes
 
     public PythonBytes swapCase() {
         return asAsciiString().withModifiedCodepoints(
-                cp -> {
-                    if (cp >= 128) {
-                        return cp;
-                    }
-                    return PythonString.CharacterCase.swapCase(cp);
-                }
-        ).asAsciiBytes();
+                cp -> cp < 128 ? PythonString.CharacterCase.swapCase(cp) : cp).asAsciiBytes();
     }
 
     public PythonBytes title() {
@@ -1692,8 +1685,7 @@ public class PythonBytes extends AbstractPythonLikeObject implements PythonBytes
 
     public PythonBytes upper() {
         return asAsciiString().withModifiedCodepoints(
-                cp -> cp < 128? Character.toUpperCase(cp) : cp
-        ).asAsciiBytes();
+                cp -> cp < 128 ? Character.toUpperCase(cp) : cp).asAsciiBytes();
     }
 
     public PythonBytes zfill(PythonInteger width) {

--- a/jpyinterpreter/src/main/java/ai/timefold/jpyinterpreter/types/PythonBytes.java
+++ b/jpyinterpreter/src/main/java/ai/timefold/jpyinterpreter/types/PythonBytes.java
@@ -372,7 +372,7 @@ public class PythonBytes extends AbstractPythonLikeObject implements PythonBytes
     }
 
     public final PythonLikeTuple asIntTuple() {
-        return IntStream.range(0, value.length).mapToObj(index -> BYTE_TO_INT[value[index]])
+        return IntStream.range(0, value.length).mapToObj(index -> BYTE_TO_INT[Byte.toUnsignedInt(value[index])])
                 .collect(Collectors.toCollection(PythonLikeTuple::new));
     }
 
@@ -397,7 +397,7 @@ public class PythonBytes extends AbstractPythonLikeObject implements PythonBytes
             throw new IndexError("position " + position + " is less than 0");
         }
 
-        return BYTE_TO_INT[value[index] & 0xFF];
+        return BYTE_TO_INT[Byte.toUnsignedInt(value[index])];
     }
 
     public PythonBytes getSubsequence(PythonSlice slice) {
@@ -472,7 +472,7 @@ public class PythonBytes extends AbstractPythonLikeObject implements PythonBytes
 
     public DelegatePythonIterator<PythonInteger> getIterator() {
         return new DelegatePythonIterator<>(IntStream.range(0, value.length)
-                .mapToObj(index -> BYTE_TO_INT[value[index]])
+                .mapToObj(index -> BYTE_TO_INT[Byte.toUnsignedInt(value[index])])
                 .iterator());
     }
 
@@ -1597,7 +1597,17 @@ public class PythonBytes extends AbstractPythonLikeObject implements PythonBytes
     }
 
     public PythonBytes capitalize() {
-        return asAsciiString().capitalize().asAsciiBytes();
+        var asString = asAsciiString();
+        if (asString.value.isEmpty()) {
+            return this;
+        }
+        var tail = PythonString.valueOf(asString.value.substring(1))
+                .withModifiedCodepoints(cp -> cp < 128? Character.toLowerCase(cp) : cp).value;
+        var head = asString.value.charAt(0);
+        if (head < 128) {
+            head = Character.toTitleCase(head);
+        }
+        return (PythonString.valueOf(head + tail)).asAsciiBytes();
     }
 
     public PythonBytes expandTabs() {
@@ -1646,7 +1656,9 @@ public class PythonBytes extends AbstractPythonLikeObject implements PythonBytes
     }
 
     public PythonBytes lower() {
-        return asAsciiString().lower().asAsciiBytes();
+        return asAsciiString().withModifiedCodepoints(
+                cp -> cp < 128? Character.toLowerCase(cp) : cp
+        ).asAsciiBytes();
     }
 
     public PythonLikeList<PythonBytes> splitLines() {
@@ -1664,15 +1676,27 @@ public class PythonBytes extends AbstractPythonLikeObject implements PythonBytes
     }
 
     public PythonBytes swapCase() {
-        return asAsciiString().swapCase().asAsciiBytes();
+        return asAsciiString().withModifiedCodepoints(
+                cp -> {
+                    if (cp >= 128) {
+                        return cp;
+                    }
+                    if (Character.isLowerCase(cp)) {
+                        return Character.toUpperCase(cp);
+                    }
+                    return Character.toLowerCase(cp);
+                }
+        ).asAsciiBytes();
     }
 
     public PythonBytes title() {
-        return asAsciiString().title().asAsciiBytes();
+        return asAsciiString().title(cp -> cp < 128).asAsciiBytes();
     }
 
     public PythonBytes upper() {
-        return asAsciiString().upper().asAsciiBytes();
+        return asAsciiString().withModifiedCodepoints(
+                cp -> cp < 128? Character.toUpperCase(cp) : cp
+        ).asAsciiBytes();
     }
 
     public PythonBytes zfill(PythonInteger width) {

--- a/jpyinterpreter/src/main/java/ai/timefold/jpyinterpreter/types/PythonBytes.java
+++ b/jpyinterpreter/src/main/java/ai/timefold/jpyinterpreter/types/PythonBytes.java
@@ -1681,10 +1681,7 @@ public class PythonBytes extends AbstractPythonLikeObject implements PythonBytes
                     if (cp >= 128) {
                         return cp;
                     }
-                    if (Character.isLowerCase(cp)) {
-                        return Character.toUpperCase(cp);
-                    }
-                    return Character.toLowerCase(cp);
+                    return PythonString.CharacterCase.swapCase(cp);
                 }
         ).asAsciiBytes();
     }

--- a/jpyinterpreter/src/main/java/ai/timefold/jpyinterpreter/types/PythonString.java
+++ b/jpyinterpreter/src/main/java/ai/timefold/jpyinterpreter/types/PythonString.java
@@ -1057,7 +1057,7 @@ public class PythonString extends AbstractPythonLikeObject implements PythonLike
         }
     }
 
-    private enum CharacterCase {
+    enum CharacterCase {
         UNCASED,
         LOWER,
         UPPER;

--- a/jpyinterpreter/src/main/java/ai/timefold/jpyinterpreter/types/PythonString.java
+++ b/jpyinterpreter/src/main/java/ai/timefold/jpyinterpreter/types/PythonString.java
@@ -11,6 +11,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.function.IntPredicate;
+import java.util.function.IntUnaryOperator;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
@@ -293,8 +294,9 @@ public class PythonString extends AbstractPythonLikeObject implements PythonLike
                 outIndex++;
             } else {
                 out[outIndex] = (byte) ((charDatum & 0xFF00) >> 8);
+                outIndex++;
                 out[outIndex] = (byte) (charDatum & 0x00FF);
-                outIndex += 2;
+                outIndex++;
             }
         }
         return new PythonBytes(out);
@@ -447,6 +449,10 @@ public class PythonString extends AbstractPythonLikeObject implements PythonLike
     }
 
     public PythonString title() {
+        return title(ignored -> true);
+    }
+
+    public PythonString title(IntPredicate predicate) {
         if (value.isEmpty()) {
             return this;
         }
@@ -458,10 +464,14 @@ public class PythonString extends AbstractPythonLikeObject implements PythonLike
         for (int i = 0; i < length; i++) {
             char character = value.charAt(i);
 
-            if (previousIsWordBoundary) {
-                out.append(Character.toTitleCase(character));
+            if (predicate.test(character)) {
+                if (previousIsWordBoundary) {
+                    out.append(Character.toTitleCase(character));
+                } else {
+                    out.append(Character.toLowerCase(character));
+                }
             } else {
-                out.append(Character.toLowerCase(character));
+                out.append(character);
             }
 
             previousIsWordBoundary = !Character.isAlphabetic(character);
@@ -476,11 +486,7 @@ public class PythonString extends AbstractPythonLikeObject implements PythonLike
     }
 
     public PythonString swapCase() {
-        return PythonString.valueOf(value.codePoints()
-                .map(CharacterCase::swapCase)
-                .collect(StringBuilder::new,
-                        StringBuilder::appendCodePoint, StringBuilder::append)
-                .toString());
+        return withModifiedCodepoints(CharacterCase::swapCase);
     }
 
     public PythonString lower() {
@@ -489,6 +495,14 @@ public class PythonString extends AbstractPythonLikeObject implements PythonLike
 
     public PythonString upper() {
         return PythonString.valueOf(value.toUpperCase());
+    }
+
+    public PythonString withModifiedCodepoints(IntUnaryOperator modifier) {
+        return PythonString.valueOf(value.codePoints()
+                .map(modifier)
+                .collect(StringBuilder::new,
+                        StringBuilder::appendCodePoint, StringBuilder::append)
+                .toString());
     }
 
     public PythonString center(PythonInteger width) {

--- a/jpyinterpreter/src/test/java/ai/timefold/jpyinterpreter/types/PythonStringTest.java
+++ b/jpyinterpreter/src/test/java/ai/timefold/jpyinterpreter/types/PythonStringTest.java
@@ -1,0 +1,41 @@
+package ai.timefold.jpyinterpreter.types;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+
+class PythonStringTest {
+
+    // Other methods are tested in test_str.py
+    // These methods are tested here since they are internal,
+    // and has edge cases CPython won't hit
+
+    @Test
+    void asAsciiBytes() {
+        var simple = PythonString.valueOf("abc");
+        assertThat(simple.asAsciiBytes().asByteArray()).isEqualTo(new byte[] { 'a', 'b', 'c'});
+
+        var unicode = PythonString.valueOf("π");
+        // UTF-16 encoding
+        assertThat(unicode.asAsciiBytes().asByteArray()).isEqualTo(new byte[] { (byte) 0x03, (byte) 0xC0 });
+
+        var mixed = PythonString.valueOf("aπc");
+        // UTF-16 encoding
+        assertThat(mixed.asAsciiBytes().asByteArray()).isEqualTo(new byte[] { 'a', (byte) 0x03, (byte) 0xC0, 'c' });
+    }
+
+    @Test
+    void asAsciiByteArray() {
+        var simple = PythonString.valueOf("abc");
+        assertThat(simple.asAsciiByteArray().asByteArray()).isEqualTo(new byte[] { 'a', 'b', 'c'});
+
+        var unicode = PythonString.valueOf("π");
+        // UTF-16 encoding
+        assertThat(unicode.asAsciiByteArray().asByteArray()).isEqualTo(new byte[] { (byte) 0x03, (byte) 0xC0 });
+
+        var mixed = PythonString.valueOf("aπc");
+        // UTF-16 encoding
+        assertThat(mixed.asAsciiByteArray().asByteArray()).isEqualTo(new byte[] { 'a', (byte) 0x03, (byte) 0xC0, 'c' });
+    }
+}

--- a/jpyinterpreter/src/test/java/ai/timefold/jpyinterpreter/types/PythonStringTest.java
+++ b/jpyinterpreter/src/test/java/ai/timefold/jpyinterpreter/types/PythonStringTest.java
@@ -1,9 +1,9 @@
 package ai.timefold.jpyinterpreter.types;
 
-import org.junit.jupiter.api.Test;
-
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.Test;
 
 class PythonStringTest {
 
@@ -14,7 +14,7 @@ class PythonStringTest {
     @Test
     void asAsciiBytes() {
         var simple = PythonString.valueOf("abc");
-        assertThat(simple.asAsciiBytes().asByteArray()).isEqualTo(new byte[] { 'a', 'b', 'c'});
+        assertThat(simple.asAsciiBytes().asByteArray()).isEqualTo(new byte[] { 'a', 'b', 'c' });
 
         var unicode = PythonString.valueOf("π");
         // UTF-16 encoding
@@ -28,7 +28,7 @@ class PythonStringTest {
     @Test
     void asAsciiByteArray() {
         var simple = PythonString.valueOf("abc");
-        assertThat(simple.asAsciiByteArray().asByteArray()).isEqualTo(new byte[] { 'a', 'b', 'c'});
+        assertThat(simple.asAsciiByteArray().asByteArray()).isEqualTo(new byte[] { 'a', 'b', 'c' });
 
         var unicode = PythonString.valueOf("π");
         // UTF-16 encoding

--- a/jpyinterpreter/tests/test_bytearray.py
+++ b/jpyinterpreter/tests/test_bytearray.py
@@ -547,6 +547,7 @@ def test_capitalize():
     capitalize_verifier.verify(bytearray(b'hello world'), expected_result=bytearray(b'Hello world'))
     capitalize_verifier.verify(bytearray(b'Hello World'), expected_result=bytearray(b'Hello world'))
     capitalize_verifier.verify(bytearray(b'HELLO WORLD'), expected_result=bytearray(b'Hello world'))
+    capitalize_verifier.verify(bytearray('π'.encode()), expected_result=bytearray('π'.encode()))
 
 
 def test_center():
@@ -915,6 +916,7 @@ def test_lower():
     lower_verifier.verify(bytearray(b'[]'), expected_result=bytearray(b'[]'))
     lower_verifier.verify(bytearray(b'-'), expected_result=bytearray(b'-'))
     lower_verifier.verify(bytearray(b'%'), expected_result=bytearray(b'%'))
+    lower_verifier.verify(bytearray('π'.encode()), expected_result=bytearray('π'.encode()))
     lower_verifier.verify(bytearray(b'\n'), expected_result=bytearray(b'\n'))
     lower_verifier.verify(bytearray(b'\t'), expected_result=bytearray(b'\t'))
     lower_verifier.verify(bytearray(b' '), expected_result=bytearray(b' '))
@@ -1273,6 +1275,7 @@ def test_swapcase():
     swapcase_verifier.verify(bytearray(b'[]'), expected_result=bytearray(b'[]'))
     swapcase_verifier.verify(bytearray(b'-'), expected_result=bytearray(b'-'))
     swapcase_verifier.verify(bytearray(b'%'), expected_result=bytearray(b'%'))
+    swapcase_verifier.verify(bytearray('π'.encode()), expected_result=bytearray('π'.encode()))
     swapcase_verifier.verify(bytearray(b'\n'), expected_result=bytearray(b'\n'))
     swapcase_verifier.verify(bytearray(b'\t'), expected_result=bytearray(b'\t'))
     swapcase_verifier.verify(bytearray(b' '), expected_result=bytearray(b' '))
@@ -1297,6 +1300,7 @@ def test_title():
     title_verifier.verify(bytearray(b'[]'), expected_result=bytearray(b'[]'))
     title_verifier.verify(bytearray(b'-'), expected_result=bytearray(b'-'))
     title_verifier.verify(bytearray(b'%'), expected_result=bytearray(b'%'))
+    title_verifier.verify(bytearray('π'.encode()), expected_result=bytearray('π'.encode()))
     title_verifier.verify(bytearray(b'\n'), expected_result=bytearray(b'\n'))
     title_verifier.verify(bytearray(b'\t'), expected_result=bytearray(b'\t'))
     title_verifier.verify(bytearray(b' '), expected_result=bytearray(b' '))

--- a/jpyinterpreter/tests/test_bytes.py
+++ b/jpyinterpreter/tests/test_bytes.py
@@ -279,6 +279,7 @@ def test_capitalize():
     capitalize_verifier.verify(b'hello world', expected_result=b'Hello world')
     capitalize_verifier.verify(b'Hello World', expected_result=b'Hello world')
     capitalize_verifier.verify(b'HELLO WORLD', expected_result=b'Hello world')
+    capitalize_verifier.verify('π'.encode(), expected_result='π'.encode())
 
 
 def test_center():
@@ -647,6 +648,7 @@ def test_lower():
     lower_verifier.verify(b'[]', expected_result=b'[]')
     lower_verifier.verify(b'-', expected_result=b'-')
     lower_verifier.verify(b'%', expected_result=b'%')
+    lower_verifier.verify('π'.encode(), expected_result='π'.encode())
     lower_verifier.verify(b'\n', expected_result=b'\n')
     lower_verifier.verify(b'\t', expected_result=b'\t')
     lower_verifier.verify(b' ', expected_result=b' ')
@@ -1005,6 +1007,7 @@ def test_swapcase():
     swapcase_verifier.verify(b'[]', expected_result=b'[]')
     swapcase_verifier.verify(b'-', expected_result=b'-')
     swapcase_verifier.verify(b'%', expected_result=b'%')
+    swapcase_verifier.verify('π'.encode(), expected_result='π'.encode())
     swapcase_verifier.verify(b'\n', expected_result=b'\n')
     swapcase_verifier.verify(b'\t', expected_result=b'\t')
     swapcase_verifier.verify(b' ', expected_result=b' ')
@@ -1029,6 +1032,7 @@ def test_title():
     title_verifier.verify(b'[]', expected_result=b'[]')
     title_verifier.verify(b'-', expected_result=b'-')
     title_verifier.verify(b'%', expected_result=b'%')
+    title_verifier.verify('π'.encode(), expected_result='π'.encode())
     title_verifier.verify(b'\n', expected_result=b'\n')
     title_verifier.verify(b'\t', expected_result=b'\t')
     title_verifier.verify(b' ', expected_result=b' ')
@@ -1061,6 +1065,7 @@ def test_upper():
     upper_verifier.verify(b'[]', expected_result=b'[]')
     upper_verifier.verify(b'-', expected_result=b'-')
     upper_verifier.verify(b'%', expected_result=b'%')
+    upper_verifier.verify('π'.encode(), expected_result='π'.encode())
     upper_verifier.verify(b'\n', expected_result=b'\n')
     upper_verifier.verify(b'\t', expected_result=b'\t')
     upper_verifier.verify(b' ', expected_result=b' ')


### PR DESCRIPTION
CPython won't ever hint the converting unicode to ascii array path (since its char sequence always has characters before 0xFF). Fix handling uppercase/lowercase in byte and bytearray methods since Python ignores char points higher than 128.
Fix missed `signed byte` -> `unsigned byte` conversions.