### PR TITLE
chore: consider genericArgs contents in TypeHint equals and hashCode

### DIFF
--- a/jpyinterpreter/src/main/java/ai/timefold/jpyinterpreter/TypeHint.java
+++ b/jpyinterpreter/src/main/java/ai/timefold/jpyinterpreter/TypeHint.java
@@ -52,4 +52,14 @@ public record TypeHint(PythonLikeType type, List<AnnotationMetadata> annotationL
     public int hashCode() {
         return Objects.hash(type, annotationList, Arrays.hashCode(genericArgs), javaGetterType);
     }
+
+    @Override
+    public String toString() {
+        return "TypeHint{" +
+                "type=" + type +
+                ", annotationList=" + annotationList +
+                ", genericArgs=" + Arrays.toString(genericArgs) +
+                ", javaGetterType=" + javaGetterType +
+                '}';
+    }
 }

--- a/jpyinterpreter/src/main/java/ai/timefold/jpyinterpreter/TypeHint.java
+++ b/jpyinterpreter/src/main/java/ai/timefold/jpyinterpreter/TypeHint.java
@@ -1,8 +1,10 @@
 package ai.timefold.jpyinterpreter;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.Objects;
 
 import ai.timefold.jpyinterpreter.types.PythonLikeType;
 
@@ -31,4 +33,23 @@ public record TypeHint(PythonLikeType type, List<AnnotationMetadata> annotationL
         return new TypeHint(type, Collections.emptyList());
     }
 
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof TypeHint typeHint)) {
+            return false;
+        }
+        return Objects.equals(type, typeHint.type) && Objects.deepEquals(genericArgs,
+                typeHint.genericArgs)
+                && Objects.equals(javaGetterType,
+                        typeHint.javaGetterType)
+                && Objects.equals(annotationList, typeHint.annotationList);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(type, annotationList, Arrays.hashCode(genericArgs), javaGetterType);
+    }
 }


### PR DESCRIPTION
Although we don't use TypeHint in maps nor sets and don't currently check them for equality, we might do it later.